### PR TITLE
Support TimeSpans interface to go back to continuous time

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AlignedSpans"
 uuid = "72438786-fd5d-49ef-8843-650acbdfe662"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"

--- a/README.md
+++ b/README.md
@@ -7,16 +7,8 @@
 
 ## Usage
 
-The main object is `AlignedSpan` which takes in a `sample_rate`, a `span`, and a description of how to round time endpoints to indices. This constructs an `AlignedSpan` which supports Onda indexing. Internally, an `AlignedSpan` stores indices, not times, and any rounding happens when it is created instead of when indexing into `samples`.
+AlignedSpans exists to help control interconversion between continuous time spans (such as those provided by TimeSpans.jl), and discrete indices, such as those associated to signals sampled at some finite rate (e.g. Onda.jl's `Samples` objects).
 
-Rounding options:
-
-* `EndpointRoundingMode`: consists of a `RoundingMode` for the `start` and `stop` of the span.
-    * The alias `RoundInward = EndpointRoundingMode(RoundUp, RoundDown)`, for example, constructs the largest span (whose endpoints are valid indices) that is entirely contained within `span`.
-    * The alias `RoundEndsDown = EndpointRoundingMode(RoundDown, RoundDown)` matches the rounding semantics of `TimeSpans.index_from_time(sample_rate, span)`.
-* `ConstantSamplesRoundingMode` consists of a `RoundingMode` for the `start` alone. The `stop` is determined from the `start` plus a number of samples which is a function only of the sampling rate and the `duration` of the span.
-
-Also provides a helper `consecutive_subspans` to partition an `AlignedSpan` into smaller consecutive `AlignedSpans` of equal size (except possibly the last one).
-
+AlignedSpans provides an `AlignedSpan` type which holds integer indices along with a sample rate. An `AlignedSpan` is thus an discrete index, but since it holds the sample rate, it can be used to represent a continuous time span as well, and it supports the TimeSpans.jl interface.
 
 See the [documentation](https://beacon-biosignals.github.io/AlignedSpans.jl/) for more.

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -18,5 +18,5 @@ three methods may be defined. These are not exported, because they are generally
 ```@docs
 AlignedSpans.start_index_from_time
 AlignedSpans.stop_index_from_time
-AlignedSpans.duration
+TimeSpans.duration
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,6 +6,46 @@ CurrentModule = AlignedSpans
 
 See [API documentation](@ref) for how to construct AlignedSpans, along with some utilities, or below for some examples and motivation.
 
+### Continuous -> Discrete
+
+Continuous timespans can be rounded (or "aligned") to the individual sample values by using the constructor `AlignedSpan`, which takes a `sample_rate`, a `span`, and a description of how to round time endpoints to indices. This constructs an `AlignedSpan` which supports Onda indexing. Internally, an `AlignedSpan` stores indices, not times, and any rounding happens when it is created instead of when indexing into `samples`.
+
+Rounding options:
+
+* `EndpointRoundingMode`: consists of a `RoundingMode` for the `start` and `stop` of the span.
+    * The alias `RoundInward = EndpointRoundingMode(RoundUp, RoundDown)`, for example, constructs the largest span (whose endpoints are valid indices) that is entirely contained within `span`.
+    * The alias `RoundEndsDown = EndpointRoundingMode(RoundDown, RoundDown)` matches the rounding semantics of `TimeSpans.index_from_time(sample_rate, span)`.
+* `ConstantSamplesRoundingMode` consists of a `RoundingMode` for the `start` alone. The `stop` is determined from the `start` plus a number of samples which is a function only of the sampling rate and the `duration` of the span.
+
+Also provides a helper `consecutive_subspans` to partition an `AlignedSpan` into smaller consecutive `AlignedSpans` of equal size (except possibly the last one).
+
+### Discrete -> Continuous 
+
+AlignedSpan's support `TimeSpans.start` and `TimeSpans.stop`, so they can be used a continuous-time spans. The semantics of this are:
+
+> For any index included in an `AlignedSpan`, the time at which the corresponding sample occurred (inclusive) to the time at which the next sample occurred (exclusive) is associated to the continuous-time representation of the span.
+
+As an example, if the sample rate is 1, and indices `2:3` are associated to a `span`, then the associated `TimeSpan` is `TimeSpan(Second(1), Second(3))`. That's because sample 2 occur at time `Second(1)`, and is considered to "last" until sample 3, which occurs at `Second(2)`. Next, sample 3 occurs at time `Second(2)` and is considered to "last" until sample 4, which occurs at `Second(3)`. Therefore, the total span associated to `2:3` is `Second(1)` to `Second(3)`.
+
+This choice of conversion matches the inclusive-inclusive indexing of Julia integer indices to the inclusive-exclusive semantics of TimeSpans.jl, and allows for roundtripping and sensible durations:
+
+```jldoctest
+julia> aligned = AlignedSpan(1, 2, 3)
+AlignedSpan(1.0, 2, 3)
+
+julia> ts = TimeSpan(aligned)
+TimeSpan(00:00:01.000000000, 00:00:03.000000000)
+
+julia> aligned == AlignedSpan(1, ts, RoundInward)
+true
+
+julia> aligned == AlignedSpan(1, ts, RoundEndsDown)
+true
+
+julia> duration(aligned) == duration(ts) == Second(2)
+true
+```
+
 ## Quick example
 
 Let's consider the following `TimeSpan`

--- a/src/AlignedSpans.jl
+++ b/src/AlignedSpans.jl
@@ -7,6 +7,9 @@ using StructTypes, ArrowTypes
 export EndpointRoundingMode, RoundInward, RoundEndsDown, ConstantSamplesRoundingMode
 export AlignedSpan, consecutive_subspans, n_samples
 
+# Make our own method so we can add methods for Intervals without piracy
+duration(span) = TimeSpans.duration(span)
+
 #####
 ##### Types and rounding modes
 #####
@@ -40,6 +43,11 @@ end
 const RoundInward = EndpointRoundingMode(RoundUp, RoundDown)
 const RoundEndsDown = EndpointRoundingMode(RoundDown, RoundDown)
 
+"""
+    AlignedSpan(sample_rate::Number, first_index::Int, last_index::Int)
+
+Construct an `AlignedSpan` directly from a `sample_rate` and indices.
+"""
 struct AlignedSpan
     sample_rate::Float64
     first_index::Int64
@@ -77,15 +85,6 @@ See also [`AlignedSpan(sample_rate, span, mode::EndpointRoundingMode)`](@ref).
 """
 function stop_index_from_time end
 
-"""
-    AlignedSpans.duration(span)
-
-Return the duration of a continuous-time `span` object.
-
-See also [`AlignedSpan(sample_rate, span, mode::ConstantSamplesRoundingMode)`](@ref)
-"""
-function duration end
-
 #####
 ##### Continuous -> discrete conversions
 #####
@@ -122,13 +121,13 @@ Creates an `AlignedSpan` whose left endpoint is rounded according to `mode.start
 and whose right endpoint is determined so by the left endpoint and the number of samples,
 given by `AlignedSpans.n_samples(sample_rate, duration(span))`.
 
-Interface: `span` may be of any type which which provides a method for [`AlignedSpans.start_index_from_time`](@ref) and [`AlignedSpans.duration`](@ref).
+Interface: `span` may be of any type which which provides a method for [`AlignedSpans.start_index_from_time`](@ref) and [`TimeSpans.duration`](@ref).
 
 ## More detailed information
 
 This is designed so that if `AlignedSpan(sample_rate, span, mode::ConstantSamplesRoundingMode)` is applied to multiple `span`s, with the same `sample_rate`, and the same durations, then the resulting `AlignedSpan`'s will have the same number of samples.
 
-For this reason, we ask for `AlignedSpans.duration(span)` to be defined, rather than a `n_samples(span)` function: the idea is that we want to only using the duration and the starting time, rather than the *actual* number of samples in this particular `span`.
+For this reason, we ask for `TimeSpans.duration(span)` to be defined, rather than a `n_samples(span)` function: the idea is that we want to only using the duration and the starting time, rather than the *actual* number of samples in this particular `span`.
 
 In contrast, `AlignedSpan(sample_rate, span, RoundInward)` provides an `AlignedSpan` which includes only (and exactly) the samples contained within `span`.
 

--- a/src/interop.jl
+++ b/src/interop.jl
@@ -38,12 +38,12 @@ function Onda.column_arguments(samples::Samples, span::AlignedSpan)
 end
 
 #####
-##### TimeSpans -> AlignedSpan
+##### TimeSpans <--> AlignedSpan
 #####
 
-# We do not support constructing a TimeSpan from an AlignedSpan,
-# because we don't have same endpoint exclusivity.
-TimeSpans.istimespan(::AlignedSpan) = false
+TimeSpans.istimespan(::AlignedSpan) = true
+TimeSpans.start(span::AlignedSpan) = time_from_index(span.sample_rate, span.first_index)
+TimeSpans.stop(span::AlignedSpan) = time_from_index(span.sample_rate, span.last_index + 1)
 
 # TimeSpan -> AlignedSpan is supported by passing to Intervals
 to_interval(span) = Interval{Nanosecond,Closed,Open}(start(span), stop(span))

--- a/src/interop.jl
+++ b/src/interop.jl
@@ -6,7 +6,6 @@ is_start_exclusive(::Interval{T,L,R}) where {T,L,R} = L == Open
 is_stop_exclusive(::Interval{T,L,R}) where {T,L,R} = R == Open
 
 # Interface methods:
-
 duration(interval::Interval{<:TimePeriod}) = last(interval) - first(interval)
 
 function start_index_from_time(sample_rate, interval::Interval,
@@ -51,8 +50,6 @@ to_interval(span::Interval) = span
 to_interval(span::AlignedSpan) = Interval(span)
 
 # Interface methods:
-
-duration(span) = duration(to_interval(span))
 
 function start_index_from_time(sample_rate, span, mode)
     return start_index_from_time(sample_rate, to_interval(span), mode)

--- a/test/interop.jl
+++ b/test/interop.jl
@@ -30,6 +30,23 @@ end
 end
 
 #####
+##### TimeSpans
+#####
+
+@testset "TimeSpans roundtripping" begin
+    for sample_rate in [1.0, 0.5, 100.0, 128.33]
+        # AlignedSpan -> TimeSpan -> AlignedSpan
+        for (i, j) in [1 => 10, 5 => 20, 3 => 6, 78 => 79]
+            for mode in (RoundEndsDown, RoundInward, ConstantSamplesRoundingMode)
+                as = AlignedSpan(sample_rate, i, j)
+                ts = TimeSpan(as)
+                @test as == AlignedSpan(sample_rate, ts, RoundEndsDown)
+            end
+        end
+    end
+end
+
+#####
 ##### Onda
 #####
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,6 +42,8 @@ end
             aligned = AlignedSpan(1, span, RoundInward)
             # Only sample included inside `span` is sample 3
             @test indices(aligned) == 3:3
+
+            @test TimeSpan(aligned) == TimeSpan(Second(2), Second(3))
         end
 
         # Does *not* contain any samples
@@ -57,6 +59,8 @@ end
             aligned = AlignedSpan(1, span, RoundEndsDown)
             # Only sample included inside `span` is sample 3, but we round left endpoint down
             @test indices(aligned) == 2:3
+
+            @test TimeSpan(aligned) == TimeSpan(Second(1), Second(3))
         end
 
         span = TimeSpan(Millisecond(2000), Millisecond(2001))

--- a/test/time_index_conversions.jl
+++ b/test/time_index_conversions.jl
@@ -52,8 +52,8 @@ end
         for i in 1:length(times), j in (i + 1):length(times)
             span = TimeSpan(times[i], times[j])
 
-            if AlignedSpans.duration(span) < Nanosecond(floor(Int, 10^9 * inv(rate)))
-                @test n_samples(rate, AlignedSpans.duration(span)) == 0
+            if duration(span) < Nanosecond(floor(Int, 10^9 * inv(rate)))
+                @test n_samples(rate, TimeSpans.duration(span)) == 0
                 continue
             end
 
@@ -62,10 +62,10 @@ end
             @test n == length(indices(aligned_span))
 
             # `n` is the *actual* number of samples, given the whole span
-            # `n_samples(rate, AlignedSpans.duration(span))` gives us the minimum
+            # `n_samples(rate, TimeSpans.duration(span))` gives us the minimum
             # number of samples of any span of that duration.
             # Thus, we should have:
-            @test n >= n_samples(rate, AlignedSpans.duration(span)) >= n - 1
+            @test n >= n_samples(rate, TimeSpans.duration(span)) >= n - 1
         end
     end
 end


### PR DESCRIPTION
closes #7 

Decided to use `TimeSpans.duration` instead of our own duration function here (in contrast to in #2), since now `AlignedSpans` are TimeSpans.jl-compatible timespans, so it's weird for them to have their own duration.

I think this is slightly breaking because `TimeSpans.istimespan` changed values, and now we use `TimeSpans.duration` instead of `AlignedSpans.duration`.