### PR TITLE
Fix `AlignedSpan(..., ::AlignedSpan, ...)` and add test

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AlignedSpans"
 uuid = "72438786-fd5d-49ef-8843-650acbdfe662"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"

--- a/src/interop.jl
+++ b/src/interop.jl
@@ -47,7 +47,6 @@ TimeSpans.stop(span::AlignedSpan) = time_from_index(span.sample_rate, span.last_
 # TimeSpan -> AlignedSpan is supported by passing to Intervals
 to_interval(span) = Interval{Nanosecond,Closed,Open}(start(span), stop(span))
 to_interval(span::Interval) = span
-to_interval(span::AlignedSpan) = Interval(span)
 
 # Interface methods:
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,20 +13,6 @@ function make_test_samples(sample_rate)
                                sample_rate), false)
 end
 
-# Interop with `StepRange`
-function Base.StepRange(span::AlignedSpan)
-    # the rounding here is not ideal
-    t = Nanosecond(round(Int, TimeSpans.nanoseconds_per_sample(span.sample_rate)))
-    return (span.i * t):t:(span.j * t)
-end
-
-function AlignedSpan(r::StepRange{T,S}) where {T<:Period,S<:Period}
-    sample_rate = TimeSpans.NS_IN_SEC / Dates.value(convert(Nanosecond, step(r)))
-    i = first(r) / step(r)
-    j = last(r) / step(r)
-    return AlignedSpan(sample_rate, Int(i), Int(j))
-end
-
 @testset "AlignedSpans.jl" begin
     @testset "Aqua" begin
         Aqua.test_all(AlignedSpans; ambiguities=false)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,6 +56,9 @@ end
         span = TimeSpan(Millisecond(1999), Millisecond(2000))
         aligned = AlignedSpan(1, span, RoundSpanDown)
         @test indices(aligned) == 2:2
+
+        # Test that we can pass an `AlignedSpan` back into the constructor
+        @test AlignedSpan(1, aligned, RoundSpanDown) == aligned
     end
 
     @testset "ConstantSamplesRoundingMode" begin


### PR DESCRIPTION
Also removes some duplicated code in the tests (the same method is in `runtests.jl` and `interop.jl`).

I noticed these issues when looking at https://github.com/beacon-biosignals/DataFrameIntervals.jl/pull/13

If we were to add an `Interval(::AlignedSpan)` constructor, I think the most natural one would be
```julia
function Intervals.Interval(span::AlignedSpan)
    L = time_from_index(span.sample_rate, span.first_index)
    R = time_from_index(span.sample_rate, span.last_index)
    return Interval{Nanosecond, Closed, Closed}(L, R)
end
```
because an `AlignedSpan` really is a closed-closed interval of indices. However, we do support mapping to TimeSpans' closed-open world.