### PR TITLE
improve docs and add asserts 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AlignedSpans"
 uuid = "72438786-fd5d-49ef-8843-650acbdfe662"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.2.7"
+version = "0.2.8"
 
 [deps]
 ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"

--- a/src/AlignedSpans.jl
+++ b/src/AlignedSpans.jl
@@ -189,7 +189,7 @@ If `mode.start==RoundUp`, then the left index of the resulting span is guarantee
 to be inside `span`. This is accomplished by checking if the left endpoint of the span
 is exclusive, and if so, incrementing the index after rounding when necessary.
 
-Likewise, if `mode.start==RoundDown`, then the right index of the resulting span is guaranteed
+Likewise, if `mode.stop==RoundDown`, then the right index of the resulting span is guaranteed
 to be inside `span`. This is accomplished by checking if the right endpoint of the span
 is exclusive, and if so, decrementing the index after rounding when necessary.
 
@@ -219,8 +219,43 @@ This is designed so that if `AlignedSpan(sample_rate, span, mode::ConstantSample
 
 For this reason, we ask for `TimeSpans.duration(span)` to be defined, rather than a `n_samples(span)` function: the idea is that we want to only using the duration and the starting time, rather than the *actual* number of samples in this particular `span`.
 
-In contrast, `AlignedSpan(sample_rate, span, RoundInward)` provides an `AlignedSpan` which includes only (and exactly) the samples contained within `span`.
+In contrast, `AlignedSpan(sample_rate, span, RoundInward)` provides an `AlignedSpan` which includes only (and exactly) the samples which occur within `span`.
 
+!!! warning
+    If the input `span` is not sample-aligned, meaning the `start` and `stop` of the input span are not exact multiples of the sample rate, the results can be non-intuitive at first. Each underlying sample is considered to occur at some instant in time (not, e.g. over a span of duration of `1/sample_rate`), and the rounding is relative to the samples themselves.
+
+    So for example:
+        
+    ```jldoctest
+    julia> using TimeSpans, AlignedSpans, Dates
+
+    julia> sample_rate = 1/30
+    0.03333333333333333
+
+    julia> input = TimeSpan(0, Second(30) + Nanosecond(1))
+    TimeSpan(00:00:00.000000000, 00:00:30.000000001)
+
+    julia> aligned = AlignedSpan(sample_rate, input, RoundInward) # or RoundSpanDown
+    AlignedSpan(0.03333333333333333, 1, 2)
+
+    julia> TimeSpan(aligned)
+    TimeSpan(00:00:00.000000000, 00:01:00.000000000)
+
+    ```
+
+    Even though we have specified `RoundInward` or `RoundSpanDown`, both of which round the right-endpoint down, the resulting sample-aligned `TimeSpan(aligned)` is `TimeSpan(0, Second(60))`.
+
+    How can this be? Clearly `Second(60) > Second(30) + Nanosecond(1)`, so what is going on?
+
+    To understand this, note that at 1/30Hz, the samples occur at 00:00, 00:30, 00:60, and so forth. The original input span
+    includes _two_ samples, the one at 00:00 and the one at 00:30. Rounding inward to include only samples that occur within the span means including both samples.
+
+    When converting back to TimeSpans, AlignedSpans canonicalizes `AlignedSpan(1/30, 1, 2)` as `TimeSpan(0, Second(60))`,
+    representing these two samples as the time from the first sample until just before the not-included sample-3 (which occurs at `Second(60)`), using that `TimeSpan`'s exclude their right endpoint.
+
+    AlignedSpans could make a different choice to e.g. canonicalize samples to only add an additional nanosecond,
+    but that has its own issue (e.g. `TimeSpan(AlignedSpan(sample_rate, 1, 2))` and `TimeSpan(AlignedSpan(sample_rate, 3, 4))` would not be consecutive).
+    
 If one wants to create a collection of consecutive, non-overlapping, `AlignedSpans` each with the same number of samples, then use [`consecutive_subspans`](@ref) instead.
 """
 function AlignedSpan(sample_rate, span, mode::ConstantSamplesRoundingMode)

--- a/src/interop.jl
+++ b/src/interop.jl
@@ -14,6 +14,13 @@ function start_index_from_time(sample_rate, interval::Interval,
     if is_start_exclusive(interval) && mode == RoundUp && iszero(error)
         first_index += 1
     end
+
+    if mode == RoundUp
+        t = time_from_index(sample_rate, first_index)
+        # this should *always* be true by construction, and we promise it in the docstring.
+        # let's add an assert to verify.
+        @assert t >= first(interval)
+    end
     return first_index
 end
 
@@ -22,6 +29,13 @@ function stop_index_from_time(sample_rate, interval::Interval,
     last_index, error = index_and_error_from_time(sample_rate, last(interval), mode)
     if is_stop_exclusive(interval) && mode == RoundDown && iszero(error)
         last_index -= 1
+    end
+
+    if mode == RoundDown
+        t = time_from_index(sample_rate, last_index)
+        # this should *always* be true by construction, and we promise it in the docstring.
+        # let's add an assert to verify.
+        @assert t <= last(interval)
     end
     return last_index
 end

--- a/test/time_index_conversions.jl
+++ b/test/time_index_conversions.jl
@@ -19,10 +19,11 @@ end
 # Modified from
 # https://github.com/beacon-biosignals/TimeSpans.jl/blob/e3c999021336e51a08d118e6defb792e38ac1cc7/test/runtests.jl#L116-L126
 @testset "index_and_error_from_time" begin
-    for rate in (101 // 2, 1001 // 10, 200, 256, 1, 10)
+    for rate in (101 // 2, 1001 // 10, 200, 256, 1, 10, 1 // 30)
         for sample_time in
             (Nanosecond(12345), Minute(5), Nanosecond(Minute(5)) + Nanosecond(1),
-             Nanosecond(1), Nanosecond(10^6), Nanosecond(6970297031))
+             Nanosecond(1), Nanosecond(10^6), Nanosecond(6970297031),
+             Nanosecond(230000000001), Nanosecond(ceil(Int, 10^9 / rate) + 1))
             # compute with a very simple algorithm
             index = naive_index_from_time(rate, sample_time)
             # Check against our `TimeSpans.index_from_time`:


### PR DESCRIPTION
[note to beaconeers: this is an open-source repo]

closes #36 ; see https://github.com/beacon-biosignals/AlignedSpans.jl/issues/36#issuecomment-2653505626 for a summary of the confusion.

I believe what is implemented is in fact correct, but this stuff is quite confusing. I've written out a big warning to try to clarify.  I've also expanded the tests a bit, and added asserts to enforce the documented behavior:

> If `mode.start==RoundUp`, then the left index of the resulting span is guaranteed
to be inside `span`. This is accomplished by checking if the left endpoint of the span
is exclusive, and if so, incrementing the index after rounding when necessary.
>
> Likewise, if `mode.stop==RoundDown`, then the right index of the resulting span is guaranteed
to be inside `span`. This is accomplished by checking if the right endpoint of the span
is exclusive, and if so, decrementing the index after rounding when necessary.

I believe these should never fire by construction. I'm not 100% sure if we want them or not; if they fire there is probably a logic bug in AlignedSpans, but do we want that to bring down some production code? Not totally sure. We could make it a warning instead if that's better, asking the user to file an issue.
