### PR TITLE
have tagbot use the right key

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -12,4 +12,4 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.BEACONBUDDY_SSH_KEY }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
this repo has a `DOCUMENTER_KEY`