### PR TITLE
fix assert violation found in #40 by canonicalizing to closed-closed intervals

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AlignedSpans"
 uuid = "72438786-fd5d-49ef-8843-650acbdfe662"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.2.8"
+version = "0.2.9"
 
 [deps]
 ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -43,7 +43,7 @@ This choice of conversion matches the inclusive-inclusive indexing of Julia inte
 julia> using AlignedSpans, TimeSpans, Dates
 
 julia> aligned = AlignedSpan(1, 2, 3)
-AlignedSpan(1.0, 2, 3)
+AlignedSpan(1, 2, 3)
 
 julia> ts = TimeSpan(aligned)
 TimeSpan(00:00:01.000000000, 00:00:03.000000000)

--- a/src/AlignedSpans.jl
+++ b/src/AlignedSpans.jl
@@ -78,7 +78,7 @@ TimeSpan(00:00:01.500000000, 00:00:02.500000000)
 The only sample within the span is at index 3. And indeed,
 ```jldoctest RoundInward
 julia> aligned = AlignedSpan(1, ts, RoundInward)
-AlignedSpan(1.0, 3, 3)
+AlignedSpan(1, 3, 3)
 
 julia> AlignedSpans.indices(aligned)
 3:3
@@ -124,7 +124,7 @@ the start of the interval becomes 1s, and the stop of the interval
 becomes 2s. Thus, the associated samples are at indices `2:3`. And indeed,
 ```jldoctest RoundSpanDown
 julia> aligned = AlignedSpan(1, ts, RoundSpanDown)
-AlignedSpan(1.0, 2, 3)
+AlignedSpan(1, 2, 3)
 
 julia> AlignedSpans.indices(aligned)
 2:3
@@ -187,7 +187,7 @@ julia> ts = TimeSpan(Millisecond(1500), Millisecond(3500))
 TimeSpan(00:00:01.500000000, 00:00:03.500000000)
 
 julia> aligned = AlignedSpan(1, ts, RoundFullyContainedSampleSpans)
-AlignedSpan(1.0, 3, 3)
+AlignedSpan(1, 3, 3)
 
 julia> AlignedSpans.indices(aligned)
 3:3
@@ -195,24 +195,41 @@ julia> AlignedSpans.indices(aligned)
 """
 const RoundFullyContainedSampleSpans = RoundingModeFullyContainedSampleSpans()
 
+function convert_sample_rate(sample_rate::Number)
+    if isinteger(sample_rate)
+        return convert(Int64, sample_rate)
+    elseif sample_rate isa Rational
+        return convert(Rational{Int64}, sample_rate)
+    else
+        return rationalize(Int64, sample_rate)
+    end
+end
+
 """
     AlignedSpan(sample_rate::Number, first_index::Int, last_index::Int)
 
 Construct an `AlignedSpan` directly from a `sample_rate` and indices.
 """
 struct AlignedSpan
-    sample_rate::Float64
+    sample_rate::Union{Int64,Rational{Int64}}
     first_index::Int64
     last_index::Int64
-    function AlignedSpan(sample_rate::Number, first_index::Int, last_index::Int)
+    function AlignedSpan(sample_rate::Number, first_index::Integer, last_index::Integer)
         if last_index < first_index
             throw(ArgumentError("Cannot create `AlignedSpan` with right-endpoint (`last_index=$(last_index)`) strictly smaller than left endpoint (`first_index=$(first_index)`)"))
         end
-        return new(convert(Float64, sample_rate), first_index, last_index)
+        return new(convert_sample_rate(sample_rate), Int64(first_index), Int64(last_index))
     end
-    function AlignedSpan(sample_rate::Number, index_range::UnitRange{Int})
+    function AlignedSpan(sample_rate::Number, index_range::UnitRange{<:Integer})
         return AlignedSpan(sample_rate, first(index_range), last(index_range))
     end
+end
+
+# Helps arrow deserialization
+function AlignedSpan(rational_sample_rate::@NamedTuple{num::I,den::I}, first_index::Integer,
+                     last_index::Integer) where {I<:Integer}
+    return AlignedSpan(rational_sample_rate.num // rational_sample_rate.den, first_index,
+                       last_index)
 end
 
 #####
@@ -275,7 +292,7 @@ Note: `span` may be of any type which which provides methods for `AlignedSpans.s
     TimeSpan(00:00:00.000000000, 00:00:30.000000001)
 
     julia> aligned = AlignedSpan(sample_rate, input, RoundInward) # or RoundSpanDown
-    AlignedSpan(0.03333333333333333, 1, 2)
+    AlignedSpan(1//30, 1, 2)
 
     julia> TimeSpan(aligned)
     TimeSpan(00:00:00.000000000, 00:01:00.000000000)
@@ -298,6 +315,7 @@ Note: `span` may be of any type which which provides methods for `AlignedSpans.s
 See also [`AlignedSpan(sample_rate, span, mode::RoundingModeFullyContainedSampleSpans)`](@ref).
 """
 function AlignedSpan(sample_rate, span, mode::SpanRoundingMode)
+    sample_rate = convert_sample_rate(sample_rate)
     first_index = start_index_from_time(sample_rate, span, mode.start)
     last_index = stop_index_from_time(sample_rate, span, mode.stop)
     return AlignedSpan(sample_rate, first_index, last_index)
@@ -323,6 +341,7 @@ In contrast, [`RoundInward`](@ref) provides an `AlignedSpan` which includes only
 If one wants to create a collection of consecutive, non-overlapping, `AlignedSpans` each with the same number of samples, then use [`consecutive_subspans`](@ref) instead.
 """
 function AlignedSpan(sample_rate, span, mode::ConstantSamplesRoundingMode)
+    sample_rate = convert_sample_rate(sample_rate)
     first_index = start_index_from_time(sample_rate, span, mode.start)
     n = n_samples(sample_rate, duration(span))
     last_index = first_index + n - 1
@@ -345,7 +364,7 @@ julia> input = TimeSpan(0, Second(30) + Nanosecond(1))
 TimeSpan(00:00:00.000000000, 00:00:30.000000001)
 
 julia> aligned = AlignedSpan(sample_rate, input, RoundFullyContainedSampleSpans)
-AlignedSpan(0.03333333333333333, 1, 1)
+AlignedSpan(1//30, 1, 1)
 
 julia> TimeSpan(aligned)
 TimeSpan(00:00:00.000000000, 00:00:30.000000000)
@@ -356,6 +375,7 @@ since only one 30s-long "sample span" is fully included in the input span.
 
 """
 function AlignedSpan(sample_rate, span, mode::RoundingModeFullyContainedSampleSpans)
+    sample_rate = convert_sample_rate(sample_rate)
     first_index = start_index_from_time(sample_rate, span, RoundUp)
     last_index = stop_index_from_time(sample_rate, span, mode)
     return AlignedSpan(sample_rate, first_index, last_index)

--- a/src/interop.jl
+++ b/src/interop.jl
@@ -10,8 +10,8 @@ duration(interval::Interval{<:TimePeriod}) = last(interval) - first(interval)
 
 function start_index_from_time(sample_rate, interval::Interval,
                                mode::Union{RoundingMode{:Up},RoundingMode{:Down}})
-    first_index, error = index_and_error_from_time(sample_rate, first(interval), mode)
-    if is_start_exclusive(interval) && mode == RoundUp && iszero(error)
+    first_index, err = index_and_error_from_time(sample_rate, first(interval), mode)
+    if is_start_exclusive(interval) && mode == RoundUp && iszero(err)
         first_index += 1
     end
 
@@ -42,8 +42,8 @@ end
 
 function stop_index_from_time(sample_rate, interval::Interval,
                               mode::Union{RoundingMode{:Up},RoundingMode{:Down}})
-    last_index, error = index_and_error_from_time(sample_rate, last(interval), mode)
-    if is_stop_exclusive(interval) && mode == RoundDown && iszero(error)
+    last_index, err = index_and_error_from_time(sample_rate, last(interval), mode)
+    if is_stop_exclusive(interval) && mode == RoundDown && iszero(err)
         last_index -= 1
     end
 

--- a/src/interop.jl
+++ b/src/interop.jl
@@ -44,8 +44,8 @@ function stop_index_from_time(sample_rate, interval::Interval{Nanosecond,Closed,
     if mode == RoundDown
         t = time_from_index(sample_rate, last_index)
         # this should *always* be true by construction, and we promise it in the docstring.
-        # let's add an check to verify. Note here we add 1ns to make it an open span again, since we've converted to closed
-        if !(t <= last(interval) + Nanosecond(1))
+        # let's add an check to verify.
+        if !(t <= last(interval))
             msg = """
             [AlignedSpans] Unexpected error in `stop_index_from_time`:
 

--- a/src/interop.jl
+++ b/src/interop.jl
@@ -7,7 +7,7 @@ duration(interval::Interval{<:TimePeriod}) = last(interval) - first(interval)
 
 function start_index_from_time(sample_rate, interval::Interval{Nanosecond,Closed,Closed},
                                mode::Union{RoundingMode{:Up},RoundingMode{:Down}})
-    first_index, _ = index_and_error_from_time(sample_rate, first(interval), mode)
+    first_index = index_from_time(sample_rate, first(interval), mode)
 
     if mode == RoundUp
         t = time_from_index(sample_rate, first_index)
@@ -39,7 +39,7 @@ end
 
 function stop_index_from_time(sample_rate, interval::Interval{Nanosecond,Closed,Closed},
                               mode::Union{RoundingMode{:Up},RoundingMode{:Down}})
-    last_index, _ = index_and_error_from_time(sample_rate, last(interval), mode)
+    last_index = index_from_time(sample_rate, last(interval), mode)
 
     if mode == RoundDown
         t = time_from_index(sample_rate, last_index)
@@ -74,7 +74,7 @@ function stop_index_from_time(sample_rate, interval::Interval{Nanosecond,Closed,
     # here we are in `RoundingModeFullyContainedSampleSpans` which means we treat each sample
     # as a closed-open span starting from each sample to just before the next sample,
     # and we are trying to round down to the last fully-enclosed sample span
-    last_index, _ = index_and_error_from_time(sample_rate, last(interval), RoundDown)
+    last_index = index_from_time(sample_rate, last(interval), RoundDown)
 
     # `time_from_index(sample_rate, last_index + 1)` gives us the _start_ of the next sample
     # we subtract 1 ns to get the (inclusive) _end_ of the span associated to this sample
@@ -117,7 +117,7 @@ end
 #####
 
 function Onda.column_arguments(samples::Samples, span::AlignedSpan)
-    span.sample_rate == samples.info.sample_rate ||
+    Float64(span.sample_rate) == samples.info.sample_rate ||
         throw(ArgumentError("Sample rate of `samples` ($(samples.info.sample_rate)) does not match sample rate of `AlignedSpan` argument ($(span.sample_rate))."))
     return indices(span)
 end
@@ -156,7 +156,17 @@ end
 ##### Serialization
 #####
 
-StructTypes.StructType(::Type{AlignedSpan}) = StructTypes.Struct()
+StructTypes.StructType(::Type{AlignedSpan}) = StructTypes.CustomStruct()
+StructTypes.lower(x::AlignedSpan) = (; x.sample_rate, x.first_index, x.last_index)
+function StructTypes.lowertype(::Type{AlignedSpan})
+    return @NamedTuple begin
+        # add Float64 to support deserializing from JSON
+        sample_rate::Union{Float64,Int64,Rational{Int64}}
+        first_index::Int64
+        last_index::Int64
+    end
+end
+StructTypes.construct(::Type{AlignedSpan}, args::NamedTuple) = AlignedSpan(args...)
 
 const ARROW_ALIGNED_SPAN = Symbol("AlignedSpans.AlignedSpan")
 ArrowTypes.arrowname(::Type{AlignedSpan}) = ARROW_ALIGNED_SPAN

--- a/src/time_index_conversions.jl
+++ b/src/time_index_conversions.jl
@@ -9,9 +9,9 @@ function time_from_index(sample_rate, sample_index)
     if isinteger(sample_rate)
         # avoid floating-point rounding issues
         # https://github.com/beacon-biosignals/AlignedSpans.jl/pull/42
-        return Nanosecond(ceil(Int, (sample_index - 1) * NS_IN_SEC  // Int(sample_rate)))
+        return Nanosecond(ceil(Int, (sample_index - 1) * NS_IN_SEC // Int(sample_rate)))
     else
-        return Nanosecond(ceil(Int, (sample_index - 1) * NS_IN_SEC  / sample_rate))
+        return Nanosecond(ceil(Int, (sample_index - 1) * (NS_IN_SEC / sample_rate)))
     end
 end
 #

--- a/src/time_index_conversions.jl
+++ b/src/time_index_conversions.jl
@@ -2,29 +2,22 @@
 # Here, we copy a few definitions from TimeSpans.jl in order to not depend on internals
 # https://github.com/beacon-biosignals/TimeSpans.jl/blob/e3c999021336e51a08d118e6defb792e38ac1cc7/src/TimeSpans.jl
 
-const NS_IN_SEC = Dates.value(Nanosecond(Second(1)))  # Number of nanoseconds in one second
+const NS_IN_SEC_128 = Int128(Dates.value(Nanosecond(Second(1))))  # Number of nanoseconds in one second
 
 # Tweaked from TimeSpans version: https://github.com/beacon-biosignals/AlignedSpans.jl/pull/2#discussion_r829582819
 function time_from_index(sample_rate, sample_index)
-    # v7 from https://github.com/beacon-biosignals/AlignedSpans.jl/pull/41#issuecomment-2732805250
-    if isinteger(sample_rate)
-        return Nanosecond(cld(Int128(sample_index - 1) * Int128(NS_IN_SEC),
-                              Int128(sample_rate)))
-    else
-        return Nanosecond(cld(Int128(sample_index - 1) * Int128(NS_IN_SEC),
-                              rationalize(sample_rate)))
-    end
+    return Nanosecond(cld(Int128(sample_index - 1) * NS_IN_SEC_128, sample_rate))
 end
 #
 ##
 
 # Helper to get the index and the rounding error in units of time
-function index_and_error_from_time(sample_rate, sample_time::Period, mode::RoundingMode)
+function index_from_time(sample_rate, sample_time::Union{Period,Dates.CompoundPeriod},
+                         mode::RoundingMode)
     time_in_nanoseconds = Dates.value(convert(Nanosecond, sample_time))
-    time_in_seconds = time_in_nanoseconds / NS_IN_SEC
-    floating_index = time_in_seconds * sample_rate + 1
-    index = round(Int, floating_index, mode)
-    return index, time_from_index(sample_rate, index) - sample_time
+    # +1 since time 0 corresponds to index 1
+    index = Int(div(Int128(time_in_nanoseconds) * sample_rate, NS_IN_SEC_128, mode) + 1)
+    return index
 end
 
 """
@@ -36,7 +29,8 @@ function n_samples(sample_rate, duration::Union{Period,Dates.CompoundPeriod})
     duration_in_nanoseconds = Dates.value(convert(Nanosecond, duration))
     duration_in_nanoseconds >= 0 ||
         throw(ArgumentError("`duration` must be >= 0 nanoseconds"))
-    duration_in_seconds = duration_in_nanoseconds / NS_IN_SEC
-    n_indices = duration_in_seconds * sample_rate
-    return floor(Int, n_indices)
+    # ensure that sample rate is Int128/rational for full precision
+    sample_rate = convert_sample_rate(sample_rate)
+    # -1 to remove the +1 in `index_from_time`; we are a difference in indices (a duration)
+    return index_from_time(sample_rate, duration, RoundDown) - 1
 end

--- a/src/time_index_conversions.jl
+++ b/src/time_index_conversions.jl
@@ -6,9 +6,12 @@ const NS_IN_SEC = Dates.value(Nanosecond(Second(1)))  # Number of nanoseconds in
 
 # Tweaked from TimeSpans version: https://github.com/beacon-biosignals/AlignedSpans.jl/pull/2#discussion_r829582819
 function time_from_index(sample_rate, sample_index)
-    # v4 from https://github.com/beacon-biosignals/AlignedSpans.jl/pull/41#issuecomment-2714077963
-    return Nanosecond(ceil(Int,
-                           (Float64(sample_index - 1) * Float64(NS_IN_SEC)) / sample_rate))
+    # v7 from https://github.com/beacon-biosignals/AlignedSpans.jl/pull/41#issuecomment-2732805250
+    if isinteger(sample_rate)
+        return Nanosecond(cld(Int128(sample_index - 1) * Int128(NS_IN_SEC), Int128(sample_rate)))
+    else
+        return Nanosecond(cld(Int128(sample_index - 1) * Int128(NS_IN_SEC), rationalize(sample_rate)))
+    end
 end
 #
 ##

--- a/src/time_index_conversions.jl
+++ b/src/time_index_conversions.jl
@@ -5,13 +5,14 @@
 const NS_IN_SEC = Dates.value(Nanosecond(Second(1)))  # Number of nanoseconds in one second
 
 # Tweaked from TimeSpans version: https://github.com/beacon-biosignals/AlignedSpans.jl/pull/2#discussion_r829582819
-nanoseconds_per_sample(sample_rate) = maybe_rational(NS_IN_SEC, sample_rate)
-
-maybe_rational(a::Integer, b::Integer) = a // b
-maybe_rational(a, b) = isinteger(b) && isinteger(b) ? Int(a) // Int(b) : a / b
-
 function time_from_index(sample_rate, sample_index)
-    return Nanosecond(ceil(Int, (sample_index - 1) * nanoseconds_per_sample(sample_rate)))
+    if isinteger(sample_rate)
+        # avoid floating-point rounding issues
+        # https://github.com/beacon-biosignals/AlignedSpans.jl/pull/42
+        return Nanosecond(ceil(Int, (sample_index - 1) * NS_IN_SEC  // Int(sample_rate)))
+    else
+        return Nanosecond(ceil(Int, (sample_index - 1) * NS_IN_SEC  / sample_rate))
+    end
 end
 #
 ##

--- a/src/time_index_conversions.jl
+++ b/src/time_index_conversions.jl
@@ -5,7 +5,10 @@
 const NS_IN_SEC = Dates.value(Nanosecond(Second(1)))  # Number of nanoseconds in one second
 
 # Tweaked from TimeSpans version: https://github.com/beacon-biosignals/AlignedSpans.jl/pull/2#discussion_r829582819
-nanoseconds_per_sample(sample_rate) = NS_IN_SEC / sample_rate
+nanoseconds_per_sample(sample_rate) = maybe_rational(NS_IN_SEC, sample_rate)
+
+maybe_rational(a::Integer, b::Integer) = a // b
+maybe_rational(a, b) = isinteger(b) && isinteger(b) ? Int(a) // Int(b) : a / b
 
 function time_from_index(sample_rate, sample_index)
     return Nanosecond(ceil(Int, (sample_index - 1) * nanoseconds_per_sample(sample_rate)))

--- a/src/time_index_conversions.jl
+++ b/src/time_index_conversions.jl
@@ -8,9 +8,11 @@ const NS_IN_SEC = Dates.value(Nanosecond(Second(1)))  # Number of nanoseconds in
 function time_from_index(sample_rate, sample_index)
     # v7 from https://github.com/beacon-biosignals/AlignedSpans.jl/pull/41#issuecomment-2732805250
     if isinteger(sample_rate)
-        return Nanosecond(cld(Int128(sample_index - 1) * Int128(NS_IN_SEC), Int128(sample_rate)))
+        return Nanosecond(cld(Int128(sample_index - 1) * Int128(NS_IN_SEC),
+                              Int128(sample_rate)))
     else
-        return Nanosecond(cld(Int128(sample_index - 1) * Int128(NS_IN_SEC), rationalize(sample_rate)))
+        return Nanosecond(cld(Int128(sample_index - 1) * Int128(NS_IN_SEC),
+                              rationalize(sample_rate)))
     end
 end
 #

--- a/src/time_index_conversions.jl
+++ b/src/time_index_conversions.jl
@@ -6,13 +6,9 @@ const NS_IN_SEC = Dates.value(Nanosecond(Second(1)))  # Number of nanoseconds in
 
 # Tweaked from TimeSpans version: https://github.com/beacon-biosignals/AlignedSpans.jl/pull/2#discussion_r829582819
 function time_from_index(sample_rate, sample_index)
-    if isinteger(sample_rate)
-        # avoid floating-point rounding issues
-        # https://github.com/beacon-biosignals/AlignedSpans.jl/pull/42
-        return Nanosecond(ceil(Int, (sample_index - 1) * NS_IN_SEC // Int(sample_rate)))
-    else
-        return Nanosecond(ceil(Int, (sample_index - 1) * (NS_IN_SEC / sample_rate)))
-    end
+    # v4 from https://github.com/beacon-biosignals/AlignedSpans.jl/pull/41#issuecomment-2714077963
+    return Nanosecond(ceil(Int,
+                           (Float64(sample_index - 1) * Float64(NS_IN_SEC)) / sample_rate))
 end
 #
 ##

--- a/test/time_index_conversions.jl
+++ b/test/time_index_conversions.jl
@@ -26,7 +26,7 @@ end
             (Nanosecond(12345), Minute(5), Nanosecond(Minute(5)) + Nanosecond(1),
              Nanosecond(1), Nanosecond(10^6), Nanosecond(6970297031),
              Nanosecond(230000000001), Nanosecond(ceil(Int, 10^9 / rate) + 1),
-             Nanosecond(1000000000))
+             Nanosecond(1000000000), Nanosecond(1000000000) - Nanosecond(1))
             # compute with a very simple algorithm
             index = naive_index_from_time(rate, sample_time)
             # Check against our `TimeSpans.index_from_time`:

--- a/test/time_index_conversions.jl
+++ b/test/time_index_conversions.jl
@@ -36,11 +36,11 @@ end
             # Check against `stop_index_from_time`. Note here we add 1ns bc on the left-hand side, `index`
             # is computed as the last sample that has occurred before or at `sample_time`, so when translated
             # into timespans, we want an inclusive right endpoint
-            # @test index ==
-            #       AlignedSpans.stop_index_from_time(rate,
-            #                                         Interval{Nanosecond,Closed,Closed}(Nanosecond(0),
-            #                                                                            sample_time),
-            #                                         RoundDown)[1]
+            @test index ==
+                  AlignedSpans.stop_index_from_time(rate,
+                                                    Interval{Nanosecond,Closed,Closed}(Nanosecond(0),
+                                                                                       sample_time),
+                                                    RoundDown)[1]
             # for TimeSpans, we add 1 to be inclusive
             @test index ==
                   AlignedSpans.stop_index_from_time(rate,

--- a/test/time_index_conversions.jl
+++ b/test/time_index_conversions.jl
@@ -19,11 +19,12 @@ end
 # Modified from
 # https://github.com/beacon-biosignals/TimeSpans.jl/blob/e3c999021336e51a08d118e6defb792e38ac1cc7/test/runtests.jl#L116-L126
 @testset "index_and_error_from_time" begin
-    for rate in (101 // 2, 1001 // 10, 200, 256, 1, 10, 1 // 30)
+    for rate in (101 // 2, 1001 // 10, 200, 256, 1, 10, 1 // 30, 180)
         for sample_time in
             (Nanosecond(12345), Minute(5), Nanosecond(Minute(5)) + Nanosecond(1),
              Nanosecond(1), Nanosecond(10^6), Nanosecond(6970297031),
-             Nanosecond(230000000001), Nanosecond(ceil(Int, 10^9 / rate) + 1))
+             Nanosecond(230000000001), Nanosecond(ceil(Int, 10^9 / rate) + 1),
+             Nanosecond(1000000000))
             # compute with a very simple algorithm
             index = naive_index_from_time(rate, sample_time)
             # Check against our `TimeSpans.index_from_time`:

--- a/test/time_index_conversions.jl
+++ b/test/time_index_conversions.jl
@@ -32,7 +32,6 @@ end
             # Check against our `TimeSpans.index_from_time`:
             @test index ==
                   AlignedSpans.index_and_error_from_time(rate, sample_time, RoundDown)[1]
-                  
             # Works even if `rate` is in Float64 precision:
             @test index ==
                   AlignedSpans.index_and_error_from_time(Float64(rate), sample_time,

--- a/test/time_index_conversions.jl
+++ b/test/time_index_conversions.jl
@@ -30,6 +30,11 @@ end
             # Check against our `TimeSpans.index_from_time`:
             @test index ==
                   AlignedSpans.index_and_error_from_time(rate, sample_time, RoundDown)[1]
+
+            # Check against `stop_index_from_time`:
+            @test index ==
+                  AlignedSpans.stop_index_from_time(rate, TimeSpan(0, sample_time), RoundDown)[1]
+                  
             # Works even if `rate` is in Float64 precision:
             @test index ==
                   AlignedSpans.index_and_error_from_time(Float64(rate), sample_time,

--- a/test/time_index_conversions.jl
+++ b/test/time_index_conversions.jl
@@ -32,26 +32,26 @@ end
             # Check against our `TimeSpans.index_from_time`:
             @test index ==
                   AlignedSpans.index_and_error_from_time(rate, sample_time, RoundDown)[1]
+                  
+            # Works even if `rate` is in Float64 precision:
+            @test index ==
+                  AlignedSpans.index_and_error_from_time(Float64(rate), sample_time,
+                                                         RoundDown)[1]
 
-            # Check against `stop_index_from_time`. Note here we add 1ns bc on the left-hand side, `index`
-            # is computed as the last sample that has occurred before or at `sample_time`, so when translated
-            # into timespans, we want an inclusive right endpoint
+            # Check against `stop_index_from_time`. On the left-hand side, `index`
+            # is computed as the last sample that has occurred before or at `sample_time`,
+            # so when translated into timespans, we want an inclusive right endpoint.
             @test index ==
                   AlignedSpans.stop_index_from_time(rate,
                                                     Interval{Nanosecond,Closed,Closed}(Nanosecond(0),
                                                                                        sample_time),
                                                     RoundDown)[1]
-            # for TimeSpans, we add 1 to be inclusive
+            # for TimeSpans, we add 1 to still be right-inclusive
             @test index ==
                   AlignedSpans.stop_index_from_time(rate,
                                                     TimeSpan(0,
                                                              sample_time + Nanosecond(1)),
                                                     RoundDown)[1]
-
-            # Works even if `rate` is in Float64 precision:
-            @test index ==
-                  AlignedSpans.index_and_error_from_time(Float64(rate), sample_time,
-                                                         RoundDown)[1]
         end
     end
 end

--- a/test/time_index_conversions.jl
+++ b/test/time_index_conversions.jl
@@ -2,7 +2,7 @@
 # i.e. what is the index of the last sample to have occurred before or at `sample_time`
 function naive_index_from_time(sample_rate, sample_time)
     # This stepping computation is prone to roundoff error, so we'll work in high precision
-    sample_time_in_seconds = big(Dates.value(Nanosecond(sample_time))) //
+    sample_time_in_seconds = big(Dates.value(convert(Nanosecond, sample_time))) //
                              big(TimeSpans.NS_IN_SEC)
     # At time 0, we are at index 1
     t = Rational{BigInt}(0 // 1)
@@ -20,7 +20,7 @@ end
 
 # Modified from
 # https://github.com/beacon-biosignals/TimeSpans.jl/blob/e3c999021336e51a08d118e6defb792e38ac1cc7/test/runtests.jl#L116-L126
-@testset "index_and_error_from_time" begin
+@testset "index_from_time" begin
     for rate in (101 // 2, 1001 // 10, 200, 256, 1, 10, 1 // 30, 180)
         for sample_time in
             (Nanosecond(12345), Minute(5), Nanosecond(Minute(5)) + Nanosecond(1),
@@ -31,11 +31,11 @@ end
             index = naive_index_from_time(rate, sample_time)
             # Check against our `TimeSpans.index_from_time`:
             @test index ==
-                  AlignedSpans.index_and_error_from_time(rate, sample_time, RoundDown)[1]
+                  AlignedSpans.index_from_time(rate, sample_time, RoundDown)[1]
             # Works even if `rate` is in Float64 precision:
             @test index ==
-                  AlignedSpans.index_and_error_from_time(Float64(rate), sample_time,
-                                                         RoundDown)[1]
+                  AlignedSpans.index_from_time(Float64(rate), sample_time,
+                                               RoundDown)[1]
 
             # Check against `stop_index_from_time`. On the left-hand side, `index`
             # is computed as the last sample that has occurred before or at `sample_time`,
@@ -123,5 +123,6 @@ end
     end
 
     # Compound periods are also handled
+
     @test n_samples(1e9, Minute(1) + Nanosecond(1)) == 60 * 1e9 + 1
 end


### PR DESCRIPTION
closes #40 

with the new tests, before 1c3a7db2174ba51a927c4b4f1f0b96f8651da320 :
```julia
     Testing Running tests...
index_and_error_from_time: Test Failed at /Users/eph/AlignedSpans.jl/test/time_index_conversions.jl:45
  Expression: index == (AlignedSpans.stop_index_from_time(rate, TimeSpan(0, sample_time + Nanosecond(1)), RoundDown))[1]
   Evaluated: 181 == 180

Stacktrace:
 [1] macro expansion
   @ ~/.julia/juliaup/julia-1.11.3+0.aarch64.apple.darwin14/share/julia/stdlib/v1.11/Test/src/Test.jl:679 [inlined]
 [2] macro expansion
   @ ~/AlignedSpans.jl/test/time_index_conversions.jl:45 [inlined]
 [3] macro expansion
   @ ~/.julia/juliaup/julia-1.11.3+0.aarch64.apple.darwin14/share/julia/stdlib/v1.11/Test/src/Test.jl:1704 [inlined]
 [4] top-level scope
   @ ~/AlignedSpans.jl/test/time_index_conversions.jl:24
index_and_error_from_time: Error During Test at /Users/eph/AlignedSpans.jl/test/time_index_conversions.jl:45
  Test threw exception
  Expression: index == (AlignedSpans.stop_index_from_time(rate, TimeSpan(0, sample_time + Nanosecond(1)), RoundDown))[1]
  [AlignedSpans] Unexpected error in `stop_index_from_time`:
  
  - `time_from_index(sample_rate, last_index) = 1000000001 nanoseconds`
  - `last(interval) = 1000000000 nanoseconds`
  - Expected `time_from_index(sample_rate, last_index) <= last(interval)`
  
  Please file an issue on AlignedSpans.jl: https://github.com/beacon-biosignals/AlignedSpans.jl/issues/new
  
  Stacktrace:
   [1] error(s::String)
     @ Base ./error.jl:35
   [2] stop_index_from_time(sample_rate::Int64, interval::Interval{Nanosecond, Closed, Open}, mode::RoundingMode{:Down})
     @ AlignedSpans ~/AlignedSpans.jl/src/interop.jl:66
   [3] stop_index_from_time(sample_rate::Int64, span::TimeSpan, mode::RoundingMode{:Down})
     @ AlignedSpans ~/AlignedSpans.jl/src/interop.jl:142
   [4] macro expansion
     @ ~/.julia/juliaup/julia-1.11.3+0.aarch64.apple.darwin14/share/julia/stdlib/v1.11/Test/src/Test.jl:676 [inlined]
   [5] macro expansion
     @ ~/AlignedSpans.jl/test/time_index_conversions.jl:45 [inlined]
   [6] macro expansion
     @ ~/.julia/juliaup/julia-1.11.3+0.aarch64.apple.darwin14/share/julia/stdlib/v1.11/Test/src/Test.jl:1704 [inlined]
   [7] top-level scope
     @ ~/AlignedSpans.jl/test/time_index_conversions.jl:24
(aligned, sample_rate, dur) = (AlignedSpan(1.0, 1, 100), 1, Second(1))
(aligned, sample_rate, dur) = (AlignedSpan(1.0, 1, 100), 1, Second(9))
(aligned, sample_rate, dur) = (AlignedSpan(1.0, 1, 100), 1, Millisecond(2500))
(aligned, sample_rate, dur) = (AlignedSpan(1.0, 1, 100), 1, Millisecond(1111))
Test Summary:                        | Pass  Fail  Error  Total   Time
AlignedSpans.jl                      | 5984     1      1   5986  13.9s
  Aqua                               |    6                   6   1.6s
  Construction from indices directly |    5                   5   0.1s
  RoundInward                        |   14                  14   0.0s
  RoundSpanDown                      |   11                  11   0.0s
  ConstantSamplesRoundingMode        |  505                 505   0.0s
  StepRange roundtripping            |   60                  60   0.0s
  TimeSpans roundtripping            |   60                  60   0.1s
  Samples indexing                   |   36                  36   0.0s
  JSON3 roundtripping                |    1                   1   1.7s
  Arrow roundtripping                |    1                   1   5.0s
  index_and_error_from_time          |  238     1      1    240   3.2s
  RoundFullyContainedSampleSpans     |    8                   8   0.1s
  time_from_index                    |    2                   2   0.0s
  `n_samples`                        | 3871                3871   0.0s
  consecutive_subspans               | 1154                1154   0.0s
  consecutive_overlapping_subspans   |   11                  11   0.3s
ERROR: LoadError: Some tests did not pass: 5984 passed, 1 failed, 1 errored, 0 broken.
in expression starting at /Users/eph/AlignedSpans.jl/test/runtests.jl:28
ERROR: Package AlignedSpans errored during testing
```

i.e. we can repro the issue, and found a counting error.

After:

```julia
     Testing Running tests...
(aligned, sample_rate, dur) = (AlignedSpan(1.0, 1, 100), 1, Second(1))
(aligned, sample_rate, dur) = (AlignedSpan(1.0, 1, 100), 1, Second(9))
(aligned, sample_rate, dur) = (AlignedSpan(1.0, 1, 100), 1, Millisecond(2500))
(aligned, sample_rate, dur) = (AlignedSpan(1.0, 1, 100), 1, Millisecond(1111))
Test Summary:   | Pass  Total   Time
AlignedSpans.jl | 5986   5986  12.2s
     Testing AlignedSpans tests passed 
```

i.e. we have fixed the issue.

---

notes:

- This revealed we weren't adequately testing `stop_index_from_time`. Somehow I thought it was being tested in that gnarly loop of tough cases, but we were only testing `index_and_error_from_time` instead. We should add tests for `start_index_from_time` too.
- here I have removed the sketchy `if is_stop_exclusive(interval) && mode == RoundDown && iszero(error)` bit which I think was a crude and sometimes incorrect version of canonicalizing to closed-closed intervals. By doing the latter in `to_interval`, it is much simpler to do all the logic afterwards. However it does mean we need +1ns and -1ns here and there, which obviously can be a source of bugs.
- we no longer use the `err` return from `index_and_error_from_time` so we could refactor that function, but I don't want to do that in this PR necessarily
- this also solves the shadowing issue shown in #40 (bad stacktrace w/ asserts on)
- I also added `maxlog=100` to try to not spam warnings, and improved the warning/error message to make it easier reproduce if something goes wrong
- this needs careful review I think

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210241584378583