### PR TITLE
Attempt to handle floating point weirdness with rationals

### DIFF
--- a/src/interop.jl
+++ b/src/interop.jl
@@ -44,8 +44,8 @@ function stop_index_from_time(sample_rate, interval::Interval{Nanosecond,Closed,
     if mode == RoundDown
         t = time_from_index(sample_rate, last_index)
         # this should *always* be true by construction, and we promise it in the docstring.
-        # let's add an check to verify. Note here we add 1ns to make it an open span again, since we've converted to closed
-        if !(t < last(interval) + Nanosecond(1))
+        # let's add an check to verify.
+        if !(t <= last(interval))
             msg = """
             [AlignedSpans] Unexpected error in `stop_index_from_time`:
 

--- a/src/interop.jl
+++ b/src/interop.jl
@@ -45,7 +45,7 @@ function stop_index_from_time(sample_rate, interval::Interval{Nanosecond,Closed,
         t = time_from_index(sample_rate, last_index)
         # this should *always* be true by construction, and we promise it in the docstring.
         # let's add an check to verify. Note here we add 1ns to make it an open span again, since we've converted to closed
-        if !(t <= last(interval) + Nanosecond(1))
+        if !(t < last(interval) + Nanosecond(1))
             msg = """
             [AlignedSpans] Unexpected error in `stop_index_from_time`:
 

--- a/src/time_index_conversions.jl
+++ b/src/time_index_conversions.jl
@@ -5,7 +5,10 @@
 const NS_IN_SEC = Dates.value(Nanosecond(Second(1)))  # Number of nanoseconds in one second
 
 # Tweaked from TimeSpans version: https://github.com/beacon-biosignals/AlignedSpans.jl/pull/2#discussion_r829582819
-nanoseconds_per_sample(sample_rate) = NS_IN_SEC / sample_rate
+nanoseconds_per_sample(sample_rate) = maybe_rational(NS_IN_SEC, sample_rate)
+
+maybe_rational(a::Integer, b::Integer) = a // b
+maybe_rational(a, b) = isinteger(b) && isinteger(b) ? Int(a) // Int(b) : a / b
 
 function time_from_index(sample_rate, sample_index)
     return Nanosecond(ceil(Int, (sample_index - 1) * nanoseconds_per_sample(sample_rate)))


### PR DESCRIPTION
This builds on #41, using rational type where we can get times from sample
numbers.  It restores the original and I believe correct assert check, but still
handles the additional test cases introduced in #41.