### PR TITLE
use rational/int sampling rates

### DIFF
--- a/src/time_index_conversions.jl
+++ b/src/time_index_conversions.jl
@@ -2,29 +2,21 @@
 # Here, we copy a few definitions from TimeSpans.jl in order to not depend on internals
 # https://github.com/beacon-biosignals/TimeSpans.jl/blob/e3c999021336e51a08d118e6defb792e38ac1cc7/src/TimeSpans.jl
 
-const NS_IN_SEC = Dates.value(Nanosecond(Second(1)))  # Number of nanoseconds in one second
+const NS_IN_SEC_128 = Int128(Dates.value(Nanosecond(Second(1))))  # Number of nanoseconds in one second
 
 # Tweaked from TimeSpans version: https://github.com/beacon-biosignals/AlignedSpans.jl/pull/2#discussion_r829582819
 function time_from_index(sample_rate, sample_index)
-    # v7 from https://github.com/beacon-biosignals/AlignedSpans.jl/pull/41#issuecomment-2732805250
-    if isinteger(sample_rate)
-        return Nanosecond(cld(Int128(sample_index - 1) * Int128(NS_IN_SEC),
-                              Int128(sample_rate)))
-    else
-        return Nanosecond(cld(Int128(sample_index - 1) * Int128(NS_IN_SEC),
-                              rationalize(sample_rate)))
-    end
+    return Nanosecond(cld(Int128(sample_index - 1) * NS_IN_SEC_128, sample_rate))
 end
 #
 ##
 
 # Helper to get the index and the rounding error in units of time
-function index_and_error_from_time(sample_rate, sample_time::Period, mode::RoundingMode)
+function index_from_time(sample_rate, sample_time::Union{Period, Dates.CompoundPeriod}, mode::RoundingMode)
     time_in_nanoseconds = Dates.value(convert(Nanosecond, sample_time))
-    time_in_seconds = time_in_nanoseconds / NS_IN_SEC
-    floating_index = time_in_seconds * sample_rate + 1
-    index = round(Int, floating_index, mode)
-    return index, time_from_index(sample_rate, index) - sample_time
+    # +1 since time 0 corresponds to index 1
+    index = Int(div(Int128(time_in_nanoseconds) * sample_rate, NS_IN_SEC_128, mode) + 1)
+    return index
 end
 
 """
@@ -36,7 +28,6 @@ function n_samples(sample_rate, duration::Union{Period,Dates.CompoundPeriod})
     duration_in_nanoseconds = Dates.value(convert(Nanosecond, duration))
     duration_in_nanoseconds >= 0 ||
         throw(ArgumentError("`duration` must be >= 0 nanoseconds"))
-    duration_in_seconds = duration_in_nanoseconds / NS_IN_SEC
-    n_indices = duration_in_seconds * sample_rate
-    return floor(Int, n_indices)
+    # -1 to remove the +1 in `index_from_time`; we are a difference in indices (a duration)
+    return index_from_time(sample_rate, duration, RoundDown) - 1
 end

--- a/test/time_index_conversions.jl
+++ b/test/time_index_conversions.jl
@@ -2,7 +2,7 @@
 # i.e. what is the index of the last sample to have occurred before or at `sample_time`
 function naive_index_from_time(sample_rate, sample_time)
     # This stepping computation is prone to roundoff error, so we'll work in high precision
-    sample_time_in_seconds = big(Dates.value(Nanosecond(sample_time))) //
+    sample_time_in_seconds = big(Dates.value(convert(Nanosecond, sample_time))) //
                              big(TimeSpans.NS_IN_SEC)
     # At time 0, we are at index 1
     t = Rational{BigInt}(0 // 1)
@@ -20,7 +20,7 @@ end
 
 # Modified from
 # https://github.com/beacon-biosignals/TimeSpans.jl/blob/e3c999021336e51a08d118e6defb792e38ac1cc7/test/runtests.jl#L116-L126
-@testset "index_and_error_from_time" begin
+@testset "index_from_time" begin
     for rate in (101 // 2, 1001 // 10, 200, 256, 1, 10, 1 // 30, 180)
         for sample_time in
             (Nanosecond(12345), Minute(5), Nanosecond(Minute(5)) + Nanosecond(1),
@@ -31,10 +31,10 @@ end
             index = naive_index_from_time(rate, sample_time)
             # Check against our `TimeSpans.index_from_time`:
             @test index ==
-                  AlignedSpans.index_and_error_from_time(rate, sample_time, RoundDown)[1]
+                  AlignedSpans.index_from_time(rate, sample_time, RoundDown)[1]
             # Works even if `rate` is in Float64 precision:
             @test index ==
-                  AlignedSpans.index_and_error_from_time(Float64(rate), sample_time,
+                  AlignedSpans.index_from_time(Float64(rate), sample_time,
                                                          RoundDown)[1]
 
             # Check against `stop_index_from_time`. On the left-hand side, `index`
@@ -123,5 +123,6 @@ end
     end
 
     # Compound periods are also handled
+
     @test n_samples(1e9, Minute(1) + Nanosecond(1)) == 60 * 1e9 + 1
 end


### PR DESCRIPTION
alternative or followup to #41 

this uses rational or integer sampling rates inside the AlignedSpan struct. This has the advantage over some of the commits in #41 by doing the rationalize call only once, rather than each `time_from_index` call. It also updates `index_from_time` and `n_samples` to use the high precision constructions, rather than only `time_from_index` like in #41. It also allows the user to pass rational values directly, e.g. `1//30` for hypnograms, which means there's no `rationalize` call at all. So I think this can allow for reasonable performance with integer sampling rates and user-supplied rational sampling rates, and slow-but-correct performance for user-supplied float-typed non-integer sampling rates.

This is failing a JSON roundtripping test, which I assume is figureoutable, and a `n_samples` test, which might be a test bug, not really sure.

Putting it up for comment.