### PR TITLE
[docs] change terminology (time vs sample index, not continuous vs discrete)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@
 
 AlignedSpans converts between time spans and sample indices. Time spans describe a time interval down to a resolution of 1 ns and are usually provided by TimeSpans.jl. Sample indices are associated to signals sampled at some finite rate (e.g. Onda.jl's `Samples` objects). 
 
-AlignedSpans provides an `AlignedSpan` type which holds integer indices along with a sample rate. An `AlignedSpan` is thus a pair of sample indices, but since it holds the sample rate, it can be used to represent a time span as well, and it supports the TimeSpans.jl interface.
+AlignedSpans provides an `AlignedSpan` type which holds integer sample indices along with a sample rate. An `AlignedSpan` is thus a pair of sample indices, but since it holds the sample rate, it can be used to represent a time span as well, and it supports the TimeSpans.jl interface.
 
 See the [documentation](https://beacon-biosignals.github.io/AlignedSpans.jl/) for more.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 
 ## Usage
 
-AlignedSpans converts between continuous time spans and discrete sample indices. Time spans describe a time intervals down to a resolution of 1 ns and are usually provided by TimeSpans.jl. Discrete sample indices are associated to signals sampled at some finite rate (e.g. Onda.jl's `Samples` objects). 
+AlignedSpans converts between time spans and sample indices. Time spans describe a time interval down to a resolution of 1 ns and are usually provided by TimeSpans.jl. Sample indices are associated to signals sampled at some finite rate (e.g. Onda.jl's `Samples` objects). 
 
-AlignedSpans provides an `AlignedSpan` type which holds integer indices along with a sample rate. An `AlignedSpan` is thus an discrete index, but since it holds the sample rate, it can be used to represent a continuous time span as well, and it supports the TimeSpans.jl interface.
+AlignedSpans provides an `AlignedSpan` type which holds integer indices along with a sample rate. An `AlignedSpan` is thus a pair of sample indices, but since it holds the sample rate, it can be used to represent a time span as well, and it supports the TimeSpans.jl interface.
 
 See the [documentation](https://beacon-biosignals.github.io/AlignedSpans.jl/) for more.

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -15,9 +15,9 @@ n_samples
 AlignedSpans.indices
 ```
 
-## Interface for conversion from continuous time spans
+## Interface for conversion from time spans
 
-In order to support conversion of continuous time `span` types to [`AlignedSpan`](@ref)'s,
+In order to support conversion of time `span` types to [`AlignedSpan`](@ref)'s,
 three methods may be defined. These are not exported, because they are generally not used directly, but rather defined in order to facilitate use of the [`AlignedSpan`](@ref) constructors.
 
 ```@docs

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,9 +6,9 @@ CurrentModule = AlignedSpans
 
 See [API documentation](@ref) for how to construct AlignedSpans, along with some utilities, or below for some examples and motivation.
 
-### Continuous -> Discrete
+### Time -> Sample index
 
-Continuous timespans can be rounded (or "aligned") to the individual sample values by using the constructor `AlignedSpan`, which takes a `sample_rate`, a `span`, and a description of how to round time endpoints to indices. This constructs an `AlignedSpan` which supports Onda indexing. Internally, an `AlignedSpan` stores indices, not times, and any rounding happens when it is created instead of when indexing into `samples`.
+Timespans can be rounded (or "aligned") to the individual sample values by using the constructor `AlignedSpan`, which takes a `sample_rate`, a `span`, and a description of how to round time endpoints to indices. This constructs an `AlignedSpan` which supports Onda indexing. Internally, an `AlignedSpan` stores indices, not times, and any rounding happens when it is created instead of when indexing into `samples`.
 
 !!! note
     AlignedSpans, like Onda, primarily treats samples as instants in time (rather than spans), and cares about "which samples have occurred by such and such point in time" rather than "what sample-span is ongoing at such and such point in time". See [`RoundFullyContainedSampleSpans`](@ref) for an exception, an approach that treats samples as spans.
@@ -23,11 +23,11 @@ Rounding options:
 
 Also provides a helper `consecutive_subspans` to partition an `AlignedSpan` into smaller consecutive `AlignedSpans` of equal size (except possibly the last one).
 
-### Discrete -> Continuous 
+### Sample index -> Time
 
-AlignedSpan's support `TimeSpans.start` and `TimeSpans.stop`, so they can be used a continuous-time spans. The semantics of this are:
+AlignedSpan's support `TimeSpans.start` and `TimeSpans.stop`, so they can be used as time spans. The semantics of this are:
 
-> For any index included in an `AlignedSpan`, the time at which the corresponding sample occurred (inclusive) to the time at which the next sample occurred (exclusive) is associated to the continuous-time representation of the span.
+> For any index included in an `AlignedSpan`, the time at which the corresponding sample occurred (inclusive) to the time at which the next sample occurred (exclusive) is associated to the time representation of the span.
 
 As an example, if the sample rate is 1, and indices `2:3` are associated to a `span`, then the associated `TimeSpan` is `TimeSpan(Second(1), Second(3))`. That's because sample 2 occur at time `Second(1)`, and is considered to "last" until sample 3, which occurs at `Second(2)`. Next, sample 3 occurs at time `Second(2)` and is considered to "last" until sample 4, which occurs at `Second(3)`. Therefore, the total span associated to `2:3` is `Second(1)` to `Second(3)`.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,7 +8,7 @@ See [API documentation](@ref) for how to construct AlignedSpans, along with some
 
 ### Time -> Sample index
 
-Timespans can be rounded (or "aligned") to the individual sample values by using the constructor `AlignedSpan`, which takes a `sample_rate`, a `span`, and a description of how to round time endpoints to indices. This constructs an `AlignedSpan` which supports Onda indexing. Internally, an `AlignedSpan` stores indices, not times, and any rounding happens when it is created instead of when indexing into `samples`.
+Timespans can be rounded (or "aligned") to the individual sample values by using the constructor `AlignedSpan`, which takes a `sample_rate`, a `span`, and a description of how to round time endpoints to sample indices. This constructs an `AlignedSpan` which supports Onda indexing. Internally, an `AlignedSpan` store sample indices, not times, and any rounding happens when it is created instead of when indexing into `samples`.
 
 !!! note
     AlignedSpans, like Onda, primarily treats samples as instants in time (rather than spans), and cares about "which samples have occurred by such and such point in time" rather than "what sample-span is ongoing at such and such point in time". See [`RoundFullyContainedSampleSpans`](@ref) for an exception, an approach that treats samples as spans.
@@ -29,9 +29,9 @@ AlignedSpan's support `TimeSpans.start` and `TimeSpans.stop`, so they can be use
 
 > For any index included in an `AlignedSpan`, the time at which the corresponding sample occurred (inclusive) to the time at which the next sample occurred (exclusive) is associated to the time representation of the span.
 
-As an example, if the sample rate is 1, and indices `2:3` are associated to a `span`, then the associated `TimeSpan` is `TimeSpan(Second(1), Second(3))`. That's because sample 2 occur at time `Second(1)`, and is considered to "last" until sample 3, which occurs at `Second(2)`. Next, sample 3 occurs at time `Second(2)` and is considered to "last" until sample 4, which occurs at `Second(3)`. Therefore, the total span associated to `2:3` is `Second(1)` to `Second(3)`.
+As an example, if the sample rate is 1, and sample indices `2:3` are associated to a `span`, then the associated `TimeSpan` is `TimeSpan(Second(1), Second(3))`. That's because sample 2 occur at time `Second(1)`, and is considered to "last" until sample 3, which occurs at `Second(2)`. Next, sample 3 occurs at time `Second(2)` and is considered to "last" until sample 4, which occurs at `Second(3)`. Therefore, the total span associated to `2:3` is `Second(1)` to `Second(3)`.
 
-In diagram form, the inclusive interval of indices `[2, 3]` is associated inclusive-exclusive interval of seconds, `[1, 3)`:
+In diagram form, the inclusive interval of sample indices `[2, 3]` is associated inclusive-exclusive interval of seconds, `[1, 3)`:
 ```
 Index       1   [2    3]    4     5
 Time (s)    0   [1    2     3)    4

--- a/src/AlignedSpans.jl
+++ b/src/AlignedSpans.jl
@@ -46,7 +46,7 @@ end
 """
     RoundInward = SpanRoundingMode(RoundUp, RoundDown)
 
-This is a rounding mode where both ends of the continuous time interval are rounded "inwards"
+This is a rounding mode where both ends of the time interval are rounded "inwards"
 to construct the largest span of indices such that all samples, as instants of time, occur within the span.
 
 ## Example
@@ -90,7 +90,7 @@ const RoundInward = SpanRoundingMode(RoundUp, RoundDown)
 """
     RoundSpanDown = SpanRoundingMode(RoundDown, RoundDown)
 
-This is a rounding mode where *both* ends of the continuous time interval are rounded
+This is a rounding mode where *both* ends of the time interval are rounded
 downwards.
 
 ## Example
@@ -233,7 +233,7 @@ function AlignedSpan(rational_sample_rate::@NamedTuple{num::I,den::I}, first_ind
 end
 
 #####
-##### Continuous -> discrete interface
+##### Time -> sample index interface
 #####
 
 # Methods for these API functions are provided in `interop.jl`.
@@ -258,7 +258,7 @@ See also [`AlignedSpan(sample_rate, span, mode::SpanRoundingMode)`](@ref).
 function stop_index_from_time end
 
 #####
-##### Continuous -> discrete conversions
+##### Time -> sample index conversions
 #####
 
 """

--- a/src/AlignedSpans.jl
+++ b/src/AlignedSpans.jl
@@ -47,7 +47,7 @@ end
     RoundInward = SpanRoundingMode(RoundUp, RoundDown)
 
 This is a rounding mode where both ends of the time interval are rounded "inwards"
-to construct the largest span of indices such that all samples, as instants of time, occur within the span.
+to construct the largest span of sample indices such that all samples, as instants of time, occur within the span.
 
 ## Example
 
@@ -83,7 +83,7 @@ AlignedSpan(1, 3, 3)
 julia> AlignedSpans.indices(aligned)
 3:3
 ```
-gives an `AlignedSpan` with indices `3:3`.
+gives an `AlignedSpan` with sample indices `3:3`.
 """
 const RoundInward = SpanRoundingMode(RoundUp, RoundDown)
 
@@ -129,7 +129,7 @@ AlignedSpan(1, 2, 3)
 julia> AlignedSpans.indices(aligned)
 2:3
 ```
-gives an `AlignedSpan` with indices `2:3`.
+gives an `AlignedSpan` with sample indices `2:3`.
 """
 const RoundSpanDown = SpanRoundingMode(RoundDown, RoundDown)
 
@@ -208,7 +208,7 @@ end
 """
     AlignedSpan(sample_rate::Number, first_index::Int, last_index::Int)
 
-Construct an `AlignedSpan` directly from a `sample_rate` and indices.
+Construct an `AlignedSpan` directly from a `sample_rate` and sample indices `first_index` and `last_index`.
 """
 struct AlignedSpan
     sample_rate::Union{Int64,Rational{Int64}}

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -16,8 +16,8 @@ n_samples(aligned::AlignedSpan) = length(indices(aligned))
     consecutive_subspans(span::AlignedSpan, duration::Period; keep_last=true)
     consecutive_subspans(span::AlignedSpan, n_window_samples::Int; keep_last=true)
 
-Creates an iterator of `AlignedSpan` such that each `AlignedSpan` has consecutive indices
-which cover the original `span`'s indices (when `keep_last=true`).
+Creates an iterator of `AlignedSpan` such that each `AlignedSpan` has consecutive sample indices
+which cover the original `span`'s sample indices (when `keep_last=true`).
 
 If `keep_last=true` (the default behavior), then the last span may have fewer samples than the others, and
 
@@ -26,12 +26,12 @@ the last one, which may have fewer.
 * The number of subspans is given by `cld(n_samples(span), n_window_samples)`,
 * The number of samples in the last subspan is `r = rem(n_samples(span), n_window_samples)` unless `r=0`, in which
 case the the last subspan has the same number of samples as the rest, namely `n_window_samples`.
-* All of the indices of `span` are guaranteed to be covered by exactly one subspan
+* All of the sample indices of `span` are guaranteed to be covered by exactly one subspan
 
 If `keep_last=false`, then all spans will have the same number of samples:
 * Each span has `n_window_samples` samples (which is calculated as `n_samples(span.sample_rate, duration)` if `duration::Period` is supplied)
 * The number of subspans is given by `fld(n_samples(span), n_window_samples)`
-* The last part of the `span`'s indices may not be covered (when we can't fit in another subspan of length `n_window_samples`)
+* The last part of the `span`'s sample indices may not be covered (when we can't fit in another subspan of length `n_window_samples`)
 """
 function consecutive_subspans(span::AlignedSpan, duration::Period; keep_last=true)
     n_window_samples = n_samples(span.sample_rate, duration)

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -2,7 +2,7 @@ function test_subspans(aligned, sample_rate, dur)
     subspans = collect(consecutive_subspans(aligned, dur))
     @test length(subspans) == cld(n_samples(aligned), n_samples(sample_rate, dur))
     for i in 1:(length(subspans) - 1)
-        @test subspans[i + 1].first_index == subspans[i].last_index + 1 # consecutive indices
+        @test subspans[i + 1].first_index == subspans[i].last_index + 1 # consecutive sample indices
         @test n_samples(subspans[i]) == n_samples(sample_rate, dur) # each has as many samples as prescribed by the duration
     end
     r = rem(n_samples(aligned), n_samples(sample_rate, dur)) # last one has the remainder
@@ -25,7 +25,7 @@ function test_subspans_skip_last(aligned, sample_rate, dur)
     subspans = collect(consecutive_subspans(aligned, dur; keep_last=false))
     @test length(subspans) == fld(n_samples(aligned), n_samples(sample_rate, dur))
     for i in 1:(length(subspans) - 1)
-        @test subspans[i + 1].first_index == subspans[i].last_index + 1 # consecutive indices
+        @test subspans[i + 1].first_index == subspans[i].last_index + 1 # consecutive sample indices
         @test n_samples(subspans[i]) == n_samples(sample_rate, dur) # each has as many samples as prescribed by the duration
     end
 


### PR DESCRIPTION
I think my original terminology was confusing here, as time in nanoseconds is also discrete.  So here we just remove the discrete/continuous terminology in favor of time vs sample index.
