### PR TITLE
restructure docs, add examples and decision journal

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,7 +5,9 @@ makedocs(; modules=[AlignedSpans],
          sitename="AlignedSpans",
          authors="Beacon Biosignals, Inc.",
          pages=["Introduction" => "index.md",
-                "API Documentation" => "API.md"])
+                "Examples" => "examples.md",
+                "API Documentation" => "API.md",
+                "Design Decisions" => "decisions.md"])
 
 deploydocs(; repo="github.com/beacon-biosignals/AlignedSpans.jl.git",
            devbranch="main",

--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -1,10 +1,38 @@
 # API documentation
 
+## Choosing a rounding mode
+
+* Use `RoundSpanDown` by default, or whenever you need to match the rounding Onda/TimeSpans already use elsewhere (`TimeSpans.index_from_time(sample_rate, span)`).
+* Use `RoundInward` when you need exactly the samples that occur within a span and no others, treating each sample as an instant in time.
+* Use `ConstantSamplesRoundingMode` when you need spans of the same duration to always produce the same number of samples, regardless of how they line up with the sample rate (for example, when cutting a signal into fixed-size windows).
+* Use `RoundFullyContainedSampleSpans` when each sample represents a span of time rather than an instant (for example, a hypnogram, where each sample is a sleep-stage label covering some number of seconds), and you want only the sample-spans that are fully contained in the input span.
+
+!!! warning
+    `RoundInward` and `RoundFullyContainedSampleSpans` can give different results because they answer different questions about the same input span. Consider a 1/30Hz signal and the span `TimeSpan(0, Second(30) + Nanosecond(1))`, which contains the samples at 00:00 and 00:30:
+
+    ```jldoctest
+    julia> using TimeSpans, AlignedSpans, Dates
+
+    julia> sample_rate = 1 // 30
+    1//30
+
+    julia> input = TimeSpan(0, Second(30) + Nanosecond(1))
+    TimeSpan(00:00:00.000000000, 00:00:30.000000001)
+
+    julia> AlignedSpan(sample_rate, input, RoundInward)
+    AlignedSpan(1//30, 1, 2)
+
+    julia> AlignedSpan(sample_rate, input, RoundFullyContainedSampleSpans)
+    AlignedSpan(1//30, 1, 1)
+    ```
+
+    `RoundInward` includes both samples, since both occur within `input`. `RoundFullyContainedSampleSpans` includes only the first one, since `input` doesn't fully contain the sample-span from 00:30 to 01:00. See [Design Decisions](@ref) for why there are four separate rounding modes rather than one mode that tries to handle every case.
+
 ```@docs
 AlignedSpan
 AlignedSpans.SpanRoundingMode
-AlignedSpans.RoundInward
 AlignedSpans.RoundSpanDown
+AlignedSpans.RoundInward
 AlignedSpans.RoundFullyContainedSampleSpans
 AlignedSpan(sample_rate, span, mode::SpanRoundingMode)
 AlignedSpans.ConstantSamplesRoundingMode

--- a/docs/src/decisions.md
+++ b/docs/src/decisions.md
@@ -1,0 +1,129 @@
+```@meta
+CurrentModule = AlignedSpans
+```
+
+# Design Decisions
+
+This page records why AlignedSpans works the way it does, for maintainers and for anyone reimplementing similar functionality elsewhere. It's organized by topic, with references to the pull requests and issues where each decision was made.
+
+## Endpoints and interval representation
+
+We depend on Intervals.jl to represent span endpoints internally, rather than working only in terms of `TimeSpans.jl` ([PR #2](https://github.com/beacon-biosignals/AlignedSpans.jl/pull/2)). Originally ([PR #1](https://github.com/beacon-biosignals/AlignedSpans.jl/pull/1)), converting an `AlignedSpan` to a `TimeSpan` was done by adding one nanosecond to fake an exclusive endpoint, but this wasn't robust across `TimeSpans.jl` versions (v0.2 and v0.3 represent spans differently, and v0.3 wasn't compatible with Onda at the time). `Intervals.jl` lets us represent open and closed endpoints explicitly, so `to_interval` can convert any span-like input (a `TimeSpan`, an `Interval`, or anything else supporting `start`/`stop`) into one closed-closed `Interval{Nanosecond}` before any rounding happens.
+
+We canonicalize every input span to a closed-closed interval before rounding, rather than branching on open vs. closed endpoints inside the rounding logic ([PR #41](https://github.com/beacon-biosignals/AlignedSpans.jl/pull/41)). The earlier approach handled the closed-open case (as produced by `TimeSpan`) with an ad hoc check inside the rounding functions, which missed a case and produced an off-by-one index at some sample rates. Converting to closed-closed once, in `to_interval`, removed the need for that check, at the cost of adding and subtracting a nanosecond in a few places when converting endpoints.
+
+This mismatch between `AlignedSpan`'s indices (inclusive-inclusive) and `TimeSpan`'s endpoints (inclusive-exclusive) is visible directly:
+
+```@repl decisions_endpoints
+using AlignedSpans, TimeSpans, Dates
+
+aligned = AlignedSpan(1, 2:3) # indices 2 and 3 are both included
+
+TimeSpan(aligned) # TimeSpans.jl spans exclude their right endpoint: [1s, 3s)
+```
+
+## The index -> time conversion convention
+
+For `TimeSpans.start`/`TimeSpans.stop`, we use `start(span) = time_from_index(sample_rate, first_index)` and `stop(span) = time_from_index(sample_rate, last_index + 1)` ([PR #9](https://github.com/beacon-biosignals/AlignedSpans.jl/pull/9)). We considered instead using the time of the last sample plus one nanosecond, but rejected it for two reasons: durations would come out one sample period short of what's expected (5 samples at 1Hz would have duration `4s + 1ns` instead of `5s`), and two adjacent `AlignedSpan`s would not map to two adjacent `TimeSpan`s (there'd be a gap of almost one sample period between them). Taking the stop as the time of the sample after the last one avoids both problems, and matches the inclusive-inclusive convention of Julia's integer indices to the inclusive-exclusive convention Onda/TimeSpans use.
+
+One consequence of this choice: rounding a span down or inward, then converting the result back to a `TimeSpan`, can produce a span that looks like it grew relative to the input. This is expected; see the warning under [Sample index -> Time](@ref) for a worked example. A smaller illustration of the underlying convention:
+
+```@repl decisions_stop
+using AlignedSpans, TimeSpans, Dates
+
+aligned = AlignedSpan(1, 2:3) # samples 2 and 3, at 1Hz
+
+TimeSpan(aligned) # starts when sample 2 occurs, stops when sample 4 would occur
+
+duration(aligned) # 2 samples at 1Hz is a sensible 2 seconds, not `1s + 1ns`
+```
+
+## Sample rate representation: floating point vs. rational
+
+`AlignedSpan.sample_rate` is stored as `Union{Int64,Rational{Int64}}`, not `Float64` ([PR #44](https://github.com/beacon-biosignals/AlignedSpans.jl/pull/44)). We found that `time_from_index`, which is used throughout AlignedSpans to convert a sample index into a time, was affected by floating point error at at least one common sample rate (180 Hz): the computed nanosecond time for a given index could come out one nanosecond later than it should, tripping an internal consistency check we already had in place ([issue #40](https://github.com/beacon-biosignals/AlignedSpans.jl/issues/40)).
+
+To fix the underlying floating-point issue, we tested candidate implementations of `time_from_index` against an exact reference computed with `BigInt`/`Rational{BigInt}` arithmetic, across a range of sample rates that don't divide evenly into nanoseconds (`180`, `4//3`, `1//3`, `1//30`, `44_000`, ...) ([PR #41](https://github.com/beacon-biosignals/AlignedSpans.jl/pull/41)). Converting the sample rate to a `Rational` and doing the arithmetic in `Int128`/`Rational` matched the exact reference in every case we tried, but repeating that conversion inside every call to `time_from_index`/`index_from_time` was measurably slower. So instead ([PR #44](https://github.com/beacon-biosignals/AlignedSpans.jl/pull/44)), we do the conversion once, when an `AlignedSpan` is constructed: an integer sample rate stays an `Int64`, a sample rate that's already a `Rational` stays as-is, and anything else (typically a `Float64`) is converted with `rationalize`.
+
+This does change the type stored in `sample_rate` for callers who were previously getting a `Float64` there. We decided the correctness and performance benefits were worth it: `sample_rate` was never documented to be a `Float64`, and we judged the chance of downstream code depending on that incidental detail to be small.
+
+The conversion is visible on the constructed `AlignedSpan`:
+
+```@repl decisions_rate
+using AlignedSpans
+
+AlignedSpan(180, 1:100).sample_rate # already an Int, kept as-is
+
+AlignedSpan(1 / 30, 1:100).sample_rate # a Float64 gets rationalize'd
+
+AlignedSpan(1 // 30, 1:100).sample_rate # an exact Rational is kept as-is, with no approximation
+```
+
+## Rounding modes: why four, and how they're named
+
+We provide four rounding modes because they answer genuinely different questions about which samples a span corresponds to: `RoundSpanDown` matches `TimeSpans.index_from_time`'s existing rounding behavior; `RoundInward` gives exactly the samples that occur within the span; `ConstantSamplesRoundingMode` guarantees a fixed sample count for spans of the same duration; `RoundFullyContainedSampleSpans` treats each sample as covering a span of time rather than an instant. The first two can disagree on the same input:
+
+```@repl decisions_modes
+using AlignedSpans, TimeSpans, Dates
+
+span = TimeSpan(Millisecond(1500), Millisecond(2500))
+
+AlignedSpan(1, span, RoundSpanDown) # rounds both endpoints down: 1.5s -> 1s, 2.5s -> 2s
+
+AlignedSpan(1, span, RoundInward) # shrinks until both endpoints land on samples
+```
+
+Naming `RoundSpanDown` took a few iterations ([PR #9](https://github.com/beacon-biosignals/AlignedSpans.jl/pull/9)). We initially called it `RoundEndsDown`, with an `EndpointRoundingMode` type, but `RoundDown` is already exported by `Base` for rounding a single value, and reusing it as part of a name for rounding both ends of an interval was judged confusing. We tried `RoundEndpointsDown`, but "endpoint" was still ambiguous about which endpoint. We settled on `SpanRoundingMode`/`RoundSpanDown`, which reads as "the mode that rounds the span down."
+
+`RoundFullyContainedSampleSpans` was added later ([PR #38](https://github.com/beacon-biosignals/AlignedSpans.jl/pull/38)), after `RoundInward` produced a result that a user found surprising ([issue #36](https://github.com/beacon-biosignals/AlignedSpans.jl/issues/36)): rounding a span with `RoundInward` at 1/30Hz could produce an `AlignedSpan` that, once converted back to a `TimeSpan`, extended well past the original input. `RoundInward` was doing exactly what it's documented to do — including every sample whose instant occurs within the span — but that's not the answer you want if you think of each sample as covering a span of time, as with a hypnogram. Rather than changing `RoundInward`'s semantics, we added `RoundFullyContainedSampleSpans` as a separate mode for that case.
+
+## Warnings and asserts for internal invariants
+
+A few places in `interop.jl` check, after rounding, that the rounding did what it was supposed to do, and either raise an error or log a warning if not, depending on `AlignedSpans.ASSERTS_ON[]` (which defaults to `false`) ([PR #37](https://github.com/beacon-biosignals/AlignedSpans.jl/pull/37)). We expect these checks to never fire; if they do, it means there's a bug in AlignedSpans, not in the caller's input. We default to a rate-limited warning rather than an error because AlignedSpans is used in production data pipelines, and we'd rather flag a likely bug loudly than stop a batch job outright. Setting `ASSERTS_ON[] = true` turns these into hard errors, which is useful in testing. These checks are exactly what caught the floating-point issue described above ([issue #40](https://github.com/beacon-biosignals/AlignedSpans.jl/issues/40)).
+
+```@repl decisions_asserts
+using AlignedSpans
+
+AlignedSpans.ASSERTS_ON[] # defaults to false: violations warn, they don't throw
+
+AlignedSpans.ASSERTS_ON[] = true # useful in tests, to turn violations into hard failures
+
+AlignedSpans.ASSERTS_ON[] = false # restore the default
+```
+
+## Decisions we've deferred
+
+We allow `AlignedSpan`s with indices that don't correspond to any actual sample of a given signal, including negative indices ([issue #15](https://github.com/beacon-biosignals/AlignedSpans.jl/issues/15), [PR #16](https://github.com/beacon-biosignals/AlignedSpans.jl/pull/16)). We initially copied a `sample_time >= 0` check from `TimeSpans.index_from_time`, where it made sense, but an `AlignedSpan` isn't necessarily tied to a specific `Samples` object with a known start and duration — it's a sample-rate-aligned span of time, so restricting it to only ever describe samples that already exist doesn't hold up. (Indexing an out-of-range `AlignedSpan` into an actual `Samples` object still raises a `BoundsError` at that point.)
+
+```@repl decisions_negative
+using AlignedSpans
+
+AlignedSpan(1, -5:10) # allowed: this span starts before index 1 of some signal
+```
+
+`consecutive_subspans` supports `keep_last=false` so its behavior can match `consecutive_overlapping_subspans` ([PR #19](https://github.com/beacon-biosignals/AlignedSpans.jl/pull/19)), but we haven't extended `keep_last=true` semantics to the overlapping case ([issue #20](https://github.com/beacon-biosignals/AlignedSpans.jl/issues/20)): with overlapping windows, it's not obvious what a shorter last window should mean (if there's 8-fold overlap, do the last 7 windows all get shorter, or just the very last one?). We're leaving this until someone has a concrete use case.
+
+```@repl decisions_keep_last
+using AlignedSpans
+
+span = AlignedSpan(1, 1:10)
+
+collect(consecutive_subspans(span, 3)) # keep_last=true (default): last window is shorter
+
+collect(consecutive_subspans(span, 3; keep_last=false)) # drops the short last window instead
+
+collect(consecutive_overlapping_subspans(span, 3, 2)) # overlapping windows only ever come in the "keep_last=false" style
+```
+
+We've sketched, but not implemented, `TimeSpans.translate` for `AlignedSpan` ([issue #12](https://github.com/beacon-biosignals/AlignedSpans.jl/issues/12)) and `merge_aligned_spans` ([issue #22](https://github.com/beacon-biosignals/AlignedSpans.jl/issues/22)). The generic `TimeSpans.translate` fallback already works for `AlignedSpan`s, but shifts the time values directly and can change the resulting sample count; an `AlignedSpan`-specific implementation would shift by a number of samples instead, preserving the count:
+
+```@repl decisions_translate
+using AlignedSpans, TimeSpans, Dates
+
+span = AlignedSpan(3, 1:10) # 10 samples at 3Hz
+
+n_samples(span)
+
+shifted = TimeSpans.translate(span, Second(1)) # the generic fallback shifts the *time* and returns a TimeSpan
+
+n_samples(AlignedSpan(span.sample_rate, shifted, RoundSpanDown)) # re-rounding isn't guaranteed to match n_samples(span)
+```

--- a/docs/src/decisions.md
+++ b/docs/src/decisions.md
@@ -127,3 +127,5 @@ shifted = TimeSpans.translate(span, Second(1)) # the generic fallback shifts the
 
 n_samples(AlignedSpan(span.sample_rate, shifted, RoundSpanDown)) # re-rounding isn't guaranteed to match n_samples(span)
 ```
+
+We may add this in a future release of AlignedSpans.jl.

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -1,0 +1,193 @@
+```@meta
+CurrentModule = AlignedSpans
+```
+
+# Examples
+
+## EEG and other instant-like samples
+
+Most sensor data (EEG voltage traces, and similar) is naturally modeled with each sample as an instant in time: a sample is a single measurement taken at a point in time, not a summary of some span of time. This is the default way AlignedSpans treats samples, so `RoundInward` and `RoundSpanDown` (see [Choosing a rounding mode](@ref)) are the rounding modes to reach for.
+
+Let's consider the following `TimeSpan`
+```@repl timespan
+using TimeSpans, AlignedSpans, Dates
+
+span = TimeSpan(Millisecond(1500), Millisecond(3500))
+```
+
+If we have a 1 Hz signal, there are various ways we can index into it using this TimeSpan. One option is to round the endpoints down:
+```@repl timespan
+
+down_span = AlignedSpan(1, span, RoundSpanDown)
+
+n_samples(down_span)
+```
+The second sample of our signal occurs at time 1s (since we have a 1Hz signal that starts at 0s). When we round the starting endpoint down from 1.5s to the nearest sample, we find that sample. This can be seen as "the last sample that occurred before time 1.5s".
+
+Perhaps instead we would like to round the endpoints "inward" to only consider samples occurring with the time span:
+
+```@repl timespan
+in_span = AlignedSpan(1, span, RoundInward)
+n_samples(in_span)
+```
+
+## Hypnograms and other span-like samples
+
+Some signals, like hypnograms, are more naturally thought of as a sequence of spans rather than a sequence of instants: each sample summarizes some region of time (e.g. a 30 second sleep-stage epoch) rather than being measured at a single instant. For these, `RoundFullyContainedSampleSpans` is usually a better fit than `RoundInward`.
+
+```@repl hypnogram
+using TimeSpans, AlignedSpans, Dates
+
+sample_rate = 1 // 30
+
+input = TimeSpan(0, Second(30) + Nanosecond(1))
+
+aligned = AlignedSpan(sample_rate, input, RoundFullyContainedSampleSpans)
+
+TimeSpan(aligned)
+```
+
+Compare this to rounding the same `input` with `RoundInward`:
+
+```@repl hypnogram
+AlignedSpan(sample_rate, input, RoundInward)
+```
+
+`RoundInward` includes both the sample at 00:00 and the sample at 00:30, since both occur within `input`. `RoundFullyContainedSampleSpans` includes only the sample at 00:00, since `input` doesn't fully contain the sample-span from 00:30 to 01:00.
+
+## Getting a consistent number of samples across spans
+
+`RoundInward` and `RoundSpanDown` can give a different number of samples for two spans of the same duration, depending on how each span happens to line up with the sample rate. If instead you want every span of a given duration to have the same number of samples, for example when cutting a signal into fixed-size windows, use `ConstantSamplesRoundingMode`:
+
+```@repl windows
+using TimeSpans, AlignedSpans, Dates
+
+sample_rate = 3
+
+span1 = TimeSpan(Millisecond(100), Millisecond(1100))
+span2 = TimeSpan(Millisecond(200), Millisecond(1200))
+
+n_samples(AlignedSpan(sample_rate, span1, RoundInward))
+n_samples(AlignedSpan(sample_rate, span2, RoundInward))
+```
+
+Both spans have the same duration, but rounding inward can give a different number of samples depending on alignment. Using `ConstantSamplesRoundingMode` instead:
+
+```@repl windows
+n_samples(AlignedSpan(sample_rate, span1, ConstantSamplesRoundingMode(RoundDown)))
+n_samples(AlignedSpan(sample_rate, span2, ConstantSamplesRoundingMode(RoundDown)))
+```
+
+now both spans have the same number of samples.
+
+## Splitting a span into fixed-size or sliding windows
+
+Once you have an `AlignedSpan`, use `consecutive_subspans` to split it into consecutive, non-overlapping windows, or `consecutive_overlapping_subspans` for sliding windows with a fixed hop between them:
+
+```@repl chunking
+using AlignedSpans
+
+span = AlignedSpan(1, 1:10) # 10 samples at 1Hz
+
+collect(consecutive_subspans(span, 3)) # windows of 3 samples; the last one may be shorter
+
+collect(consecutive_subspans(span, 3; keep_last=false)) # drop the short last window instead
+
+collect(consecutive_overlapping_subspans(span, 3, 2)) # windows of 3 samples, hopping by 2
+```
+
+Use `keep_last=false` if your downstream code requires every window to have exactly the same number of samples; use the default `keep_last=true` if you'd rather keep every sample, even if the last window ends up shorter. `consecutive_overlapping_subspans` only supports the `keep_last=false` style, since it's not obvious what a partial window should mean once windows overlap.
+
+## Spans that start before or run past your recording
+
+An `AlignedSpan` doesn't need to correspond to samples that actually exist in some particular recording: it's a sample-rate-aligned span of time, and can have negative indices or indices beyond the end of any specific signal. This includes rounding a `TimeSpan` whose start time is negative, i.e. before index 1 of whatever it's relative to:
+
+```@repl outofrange
+using AlignedSpans, TimeSpans, Dates
+
+AlignedSpan(1238, TimeSpan(Nanosecond(-32), Nanosecond(2)), RoundSpanDown) # the input TimeSpan starts before time 0
+```
+
+as well as constructing a span directly from out-of-range indices:
+
+```@repl outofrange
+AlignedSpan(1, -5:10) # starts 5 samples before index 1 of some signal
+```
+
+Indexing a span like this into an actual `Samples` object raises a `BoundsError` once you try, but constructing the `AlignedSpan` itself doesn't require that a signal covering the whole span already exists.
+
+## Shifting a span in time
+
+To shift an `AlignedSpan` while keeping the same number of samples, shift its indices directly rather than converting through a `TimeSpan`:
+
+```@repl shifting
+using AlignedSpans, Dates
+
+span = AlignedSpan(3, 1:10) # 10 samples at 3Hz
+
+n = n_samples(span.sample_rate, Second(1)) # number of samples in a 1s shift
+
+shifted = AlignedSpan(span.sample_rate, (span.first_index + n):(span.last_index + n))
+
+n_samples(shifted) == n_samples(span)
+```
+
+`TimeSpans.translate(span, Second(1))` also works, but it shifts the underlying time and then re-rounds, which isn't guaranteed to preserve the number of samples. This may be improved in subsequent releases of AlignedSpans.jl.
+
+## Computing sample counts from compound durations
+
+`n_samples` accepts any `Dates.Period` or `Dates.CompoundPeriod`, so durations built up from mixed units work directly, without converting to a single unit first:
+
+```@repl compound
+using AlignedSpans, Dates
+
+n_samples(1e9, Minute(1) + Nanosecond(1))
+```
+
+## Passing an exact sample rate
+
+If you know your sample rate exactly, for example `1//30` for a hypnogram sampled every 30 seconds, you can pass that `Rational` directly to `AlignedSpan`. If you instead pass a `Float64`, such as `1/30`, it is converted to the nearest `Rational` using `rationalize`:
+
+```@repl rates
+using AlignedSpans
+
+AlignedSpan(1 // 30, 1:100).sample_rate
+
+AlignedSpan(1 / 30, 1:100).sample_rate
+```
+
+See [Design Decisions](@ref) for why sample rates are stored as an `Int` or `Rational` rather than a `Float64`.
+
+## Indexing an Onda `Samples` object: TimeSpans vs. AlignedSpans
+
+Onda's `Samples` supports indexing directly with a `TimeSpan`: `samples[:, span]`. Internally, this rounds `span`'s endpoints down to the nearest samples, matching `TimeSpans.index_from_time`. That's exactly what `RoundSpanDown` does too, so indexing with `AlignedSpan(sample_rate, span, RoundSpanDown)` gives identical results to indexing with `span` directly, but also gives you the `AlignedSpan` itself to work with. Indexing with `RoundInward` instead can give you *different* samples, since it answers a different question ("which samples occur entirely within `span`" rather than "round `span`'s endpoints down"):
+
+```@repl onda_indexing
+using Onda, TimeSpans, AlignedSpans, Dates
+
+sample_rate = 1 # 1 Hz -> slow to exaggerate the effect
+samples = Samples(permutedims(0:10), SamplesInfoV2(; sensor_type="feature", channels=["a"], sample_unit="microvolt", sample_resolution_in_unit=0.5, sample_offset_in_unit=0.0, sample_type=UInt16, sample_rate), false)
+span = TimeSpan(Millisecond(1500), Millisecond(3500))
+
+samples[:, span] # indexing directly with a TimeSpan
+```
+
+```@repl onda_indexing
+samples[:, AlignedSpan(sample_rate, span, RoundSpanDown)] # matches samples[:, span]
+```
+
+```@repl onda_indexing
+samples[:, AlignedSpan(sample_rate, span, RoundInward)] # does not match: a different set of samples
+```
+
+If you need to keep track of exactly which span of time your extracted samples correspond to (for example, to plot them against the correct time axis), construct the `AlignedSpan` with `RoundSpanDown` first, and index with that instead of the original `TimeSpan`:
+
+```@repl onda_indexing
+aligned_span = AlignedSpan(sample_rate, span, RoundSpanDown)
+
+samples[:, aligned_span] == samples[:, span]
+
+TimeSpan(aligned_span) # the actual span covered by these samples, not `span` itself
+```
+
+`span` starts at 1.5s, but the samples returned start at 1s: `TimeSpan(aligned_span)` reflects that, while `span` does not.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,7 +8,7 @@ See [API documentation](@ref) for how to construct AlignedSpans, along with some
 
 AlignedSpans, like Onda, primarily treats samples as instants in time (rather than spans), and cares about "which samples have occurred by such and such point in time" rather than "what sample-span is ongoing at such and such point in time". See [`RoundFullyContainedSampleSpans`](@ref) for an exception, an approach that treats samples as spans.
 
-### Time -> Sample index
+### Time → Sample index
 
 Timespans can be rounded (or "aligned") to the individual sample values by using the constructor `AlignedSpan`, which takes a `sample_rate`, a `span`, and a description of how to round time endpoints to sample indices. This constructs an `AlignedSpan` which supports Onda indexing. Internally, an `AlignedSpan` store sample indices, not times, and any rounding happens when it is created instead of when indexing into `samples`.
 
@@ -27,7 +27,7 @@ See [Choosing a rounding mode](@ref) for guidance on which of these to use.
 
 Also provides a helper `consecutive_subspans` to partition an `AlignedSpan` into smaller consecutive `AlignedSpans` of equal size (except possibly the last one).
 
-### Sample index -> Time
+### Sample index → Time
 
 AlignedSpan's support `TimeSpans.start` and `TimeSpans.stop`, so they can be used as time spans. The semantics of this are:
 
@@ -92,7 +92,7 @@ Let's say I want to plot some samples over time, and I have a nice function `plo
 
 ```@repl motivation
 using TimeSpans, Onda, Dates
-sample_rate = 1 # 1 Hz -> slow to exaggerate the effect
+sample_rate = 1 # 1 Hz → slow to exaggerate the effect
 samples = Samples(permutedims(0:10), SamplesInfoV2(; sensor_type="feature", channels=["a"], sample_unit="microvolt", sample_resolution_in_unit=0.5, sample_offset_in_unit=0.0, sample_type=UInt16, sample_rate), false)
 span = TimeSpan(Millisecond(1500), Millisecond(4000))
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,14 +4,13 @@ CurrentModule = AlignedSpans
 
 # AlignedSpans
 
-See [API documentation](@ref) for how to construct AlignedSpans, along with some utilities, or below for some examples and motivation.
+See [API documentation](@ref) for how to construct AlignedSpans, along with some utilities, and [Examples](@ref) for further worked examples.
+
+AlignedSpans, like Onda, primarily treats samples as instants in time (rather than spans), and cares about "which samples have occurred by such and such point in time" rather than "what sample-span is ongoing at such and such point in time". See [`RoundFullyContainedSampleSpans`](@ref) for an exception, an approach that treats samples as spans.
 
 ### Time -> Sample index
 
 Timespans can be rounded (or "aligned") to the individual sample values by using the constructor `AlignedSpan`, which takes a `sample_rate`, a `span`, and a description of how to round time endpoints to sample indices. This constructs an `AlignedSpan` which supports Onda indexing. Internally, an `AlignedSpan` store sample indices, not times, and any rounding happens when it is created instead of when indexing into `samples`.
-
-!!! note
-    AlignedSpans, like Onda, primarily treats samples as instants in time (rather than spans), and cares about "which samples have occurred by such and such point in time" rather than "what sample-span is ongoing at such and such point in time". See [`RoundFullyContainedSampleSpans`](@ref) for an exception, an approach that treats samples as spans.
 
 Rounding options:
 
@@ -20,6 +19,11 @@ Rounding options:
     * The alias `RoundSpanDown = SpanRoundingMode(RoundDown, RoundDown)` matches the rounding semantics of `TimeSpans.index_from_time(sample_rate, span)`.
 * `ConstantSamplesRoundingMode` consists of a `RoundingMode` for the `start` alone. The `stop` is determined from the `start` plus a number of samples which is a function only of the sampling rate and the `duration` of the span.
 * `RoundFullyContainedSampleSpans` This is a special rounding mode which differs from the other rounding modes by associating each sample with a _span_ (from the instant the sample occurs until just before the next sample occurs), and rounding inwards to the "sample spans" that are fully contained in the input span.
+
+See [Choosing a rounding mode](@ref) for guidance on which of these to use.
+
+!!! warning
+    If the input `span` is not sample-aligned, meaning the `start` and `stop` of the input span are not exact multiples of the sample rate, the results can be non-intuitive at first, since the rounding is relative to the samples themselves rather than to the input span's endpoints. See the warning in [Choosing a rounding mode](@ref) for a worked example.
 
 Also provides a helper `consecutive_subspans` to partition an `AlignedSpan` into smaller consecutive `AlignedSpans` of equal size (except possibly the last one).
 
@@ -37,12 +41,12 @@ Index       1   [2    3]    4     5
 Time (s)    0   [1    2     3)    4
 ```
 
-This choice of conversion matches the inclusive-inclusive indexing of Julia integer indices to the inclusive-exclusive semantics of TimeSpans.jl, and allows for roundtripping and sensible durations:
+This choice of conversion matches the inclusive-inclusive indexing of Julia integer indices to the inclusive-exclusive semantics Onda/TimeSpans use, and allows for roundtripping and sensible durations:
 
 ```jldoctest
 julia> using AlignedSpans, TimeSpans, Dates
 
-julia> aligned = AlignedSpan(1, 2, 3)
+julia> aligned = AlignedSpan(1, 2:3)
 AlignedSpan(1, 2, 3)
 
 julia> ts = TimeSpan(aligned)
@@ -59,35 +63,28 @@ true
 ```
 
 !!! warning
-    For non-integer sample rates, roundtripping perfectly is not always possible.
+    For non-integer sample rates, roundtripping perfectly is not always possible. Sample rates that aren't already an `Int` or a `Rational` are converted with `rationalize`; see [Design Decisions](@ref) for why.
 
-### Note on roundtripping
+!!! warning
+    Because the stop of the time representation of an `AlignedSpan` is the time at which the sample _after_ the last included one occurs, rounding a span and then converting it back to a `TimeSpan` can give a result that looks larger than the input. For example, at 1/30Hz, the samples occur at 00:00, 00:30, 01:00, and so on. The span `TimeSpan(0, Second(30) + Nanosecond(1))` contains two samples, the ones at 00:00 and 00:30:
 
+    ```jldoctest
+    julia> using TimeSpans, AlignedSpans, Dates
 
-## Quick example
+    julia> sample_rate = 1 // 30
+    1//30
 
-Let's consider the following `TimeSpan`
-```@repl timespan
-using TimeSpans, AlignedSpans, Dates
+    julia> input = TimeSpan(0, Second(30) + Nanosecond(1))
+    TimeSpan(00:00:00.000000000, 00:00:30.000000001)
 
-span = TimeSpan(Millisecond(1500), Millisecond(3500))
-```
+    julia> aligned = AlignedSpan(sample_rate, input, RoundInward) # or RoundSpanDown
+    AlignedSpan(1//30, 1, 2)
 
-If we have a 1 Hz signal, there are various ways we can index into it using this TimeSpan. One option is to round the endpoints down:
-```@repl timespan
+    julia> TimeSpan(aligned)
+    TimeSpan(00:00:00.000000000, 00:01:00.000000000)
+    ```
 
-down_span = AlignedSpan(1, span, RoundSpanDown)
-
-n_samples(down_span)
-```
-The second sample of our signal occurs at time 1s (since we have a 1Hz signal that starts at 0s). When we round the starting endpoint down from 1.5s to the nearest sample, we find that sample. This can be seen as "the last sample that occurred before time 1.5s".
-
-Perhaps instead we would like to round the endpoints "inward" to only consider samples occurring with the time span:
-
-```@repl timespan
-in_span = AlignedSpan(1, span, RoundInward)
-n_samples(in_span)
-```
+    Even though `RoundInward` and `RoundSpanDown` both round the right endpoint down, `TimeSpan(aligned)` is `TimeSpan(0, Second(60))`, not `TimeSpan(0, Second(30) + Nanosecond(1))`. That's because indices 1 and 2 correspond to the time from the first sample until just before the sample that would come after index 2, which occurs at `Second(60)`.
 
 ## Motivation
 


### PR DESCRIPTION
See [HERE](https://beacon-biosignals.github.io/AlignedSpans.jl/previews/PR60/) for the docs preview associated to this PR.

based on https://github.com/beacon-biosignals/AlignedSpans.jl/pull/59

used Claude sonnet 5 (medium). First had it survey the issues/prs/code and write the following notes:

<details><summary>Claude's notes</summary>

# Research notes: the semantics and history of AlignedSpans.jl

These are working notes gathered from the GitHub issue/PR history, source code
comments, and test-suite comments, meant as raw material for a pedagogical
docs writeup. Nothing here is final prose for the docs — it's a synthesis of
*why* things are the way they are, with pointers back to the primary sources
(PR/issue numbers, file:line) so context isn't lost.

## 0. The one-sentence problem statement

A "sample" is conceptually just a number (an index, 1, 2, 3, ...) but
every sample also corresponds to an instant of time, determined by
a sample rate. Converting between "index space" and "time space" sounds like
a trivial division/multiplication, but every step is full of off-by-one
choices, open/closed endpoint mismatches, and floating point traps. This
package's whole job is to make those choices *explicit, documented, and
tested*, instead of letting every caller silently re-invent (and
mis-implement) them.

Terminology note: it's tempting to call this a "continuous vs. discrete"
problem, but that's not quite right — Julia's time type here (`Nanosecond`,
an integer-backed `TimePeriod`) is itself a discretization, not real-valued
time. The actual distinction is between two *different discrete
representations at different granularities*: nanosecond-resolution time
values vs. sample-index counts. The rounding complexity in this package comes
from the fact that a sample period (`1/sample_rate` seconds) essentially
never divides evenly into whole nanoseconds (e.g. rates like `1/3`, `1/30`,
or `180` Hz), not from any continuous/discrete mismatch per se. So these
notes use **"time" vs. "sample index"** rather than "continuous" vs.
"discrete."

## 1. The foundational mental model: samples are instants, not intervals

The core design decision (see docs/src/index.md "note" admonition, and issue
#7, PR #2) is:

> AlignedSpans, like Onda, primarily treats samples as instants in time
> (rather than spans) — it cares about "which samples have occurred by such
> and such point in time" rather than "what sample-span is ongoing at such
> and such point in time."

This is a modeling choice, not a mathematical necessity — see §6 for the
alternate "sample-as-span" model (`RoundFullyContainedSampleSpans`), which
exists specifically because some data (hypnograms) violate this assumption.

Given "sample = instant", sample index `i` (1-based) occurs at time
`(i-1) / sample_rate` seconds. This is `time_from_index` in
`src/time_index_conversions.jl`.

## 2. Sample index → time is the *hard* direction

Going from time to a sample index is "just" rounding (see §3), but
going from a range of sample indices *back* to a `TimeSpan` is
where all of the real design debate happened. This is because:

- Julia integer ranges (`i:j`) are inclusive on both ends.
- `TimeSpans.jl`'s `TimeSpan` is closed-open (`[start, stop)`), matching
  standard interval-arithmetic conventions for time ranges.
- A sample is (by the model in §1) an instant, i.e. it has zero duration. So
  what time span should even correspond to "samples 2 through 3"?

### The chosen convention (PR #9, issue #7, docs/src/index.md)

> For any index included in an `AlignedSpan`, the time at which the
> corresponding sample occurred (inclusive) to the time at which the *next*
> sample occurred (exclusive) is associated to the time
> representation of the span.

Concretely: `TimeSpans.start(span) = time_from_index(sample_rate,
span.first_index)` and `TimeSpans.stop(span) = time_from_index(sample_rate,
span.last_index + 1)` (src/interop.jl:130-131). I.e. the stop time is
"one past the last index," translated to time — which is exactly what you
want for a closed-open `TimeSpan`.

Why this and not, e.g., "stop = time of last sample + 1ns"? Discussed at
length in PR #2:

- Reason 1: it makes `duration` sensible — "5 samples @ 1Hz is 5s" (issue #7).
  With the "+1ns" alternative, duration would come out as `4s + 1ns`, which is
  a worse answer to "how long is this span" even though it's a more literal
  reading of "instant to instant+1ns".
- Reason 2: it allows two adjacent `AlignedSpan`s to map to two *adjacent*
  (non-overlapping, gap-free) `TimeSpan`s. If you used "+1ns" instead,
  `TimeSpan(AlignedSpan(rate,1,2))` and `TimeSpan(AlignedSpan(rate,3,4))`
  would not be consecutive (there'd be a 1-sample-period-minus-1ns gap
  between them) — see the long "warning" admonition in
  `src/AlignedSpans.jl:280-314`.
- It matches the *inclusive-inclusive* semantics of Julia's integer indexing
  to the *inclusive-exclusive* semantics of TimeSpans, cleanly, once you
  accept "assign each sample the half-open interval up to the next sample."

This convention was actually only settled in PR #9 ("Support TimeSpans
interface to go back to continuous time" — the PR's own title still uses the
old framing), well after the initial "time → sample index" functionality
(PR #2) — PR #2's author explicitly punted on it originally (see issue #7,
opened from PR #2), preferring to get the "well-defined" time→index direction
merged first and defer the harder index→time direction. This is a good
example of scoping a genuinely hard design problem out of an initial PR
rather than rushing it.

### The corollary: non-intuitive round-trips near sample boundaries

Because "stop" is computed via "start of the sample *after* the last one",
rounding a span *inward* (or down) and then converting the sample indices
back to a `TimeSpan` can produce a result that looks like it "grew." Worked
example from
`src/AlignedSpans.jl:280-314` (also mirrored in issue #36):

```julia
sample_rate = 1/30
input = TimeSpan(0, Second(30) + Nanosecond(1))       # samples at 0, 30, 60, ...
aligned = AlignedSpan(sample_rate, input, RoundInward) # or RoundSpanDown
# -> AlignedSpan(1/30, 1, 2)   (includes samples at index 1 (t=0s) and 2 (t=30s))
TimeSpan(aligned)
# -> TimeSpan(0, Second(60))   !! not Second(30) + Nanosecond(1) !!
```

This *looks* wrong (60s ≫ 30.000000001s) but is correct: the input span
contains exactly two samples (t=0 and t=30), and per the index→time
convention, "samples 1 and 2" maps to "[time of sample 1, time of sample 3)"
= `[0, 60)`. This is the single most-referenced "gotcha" across the whole
history (issue #36, PR #37) and is exactly the kind of thing that needs a
dedicated, heavily-worked-example section in the docs, because the "obvious"
intuition (that rounding down twice should give you back something ⊆ the
original span, once mapped back to a `TimeSpan`) is false in general.

## 3. The rounding-mode taxonomy (time → sample index)

Three distinct constructors/modes exist, each answering a different question
about "which samples does this span *mean*":

1. **`SpanRoundingMode(start_mode, stop_mode)`** — round each endpoint of the
   input span independently. Two named instances:
   - `RoundSpanDown = SpanRoundingMode(RoundDown, RoundDown)`: round both
     endpoints down to the nearest existing sample. Matches
     `TimeSpans.index_from_time`'s classic semantics (docs/src/index.md).
     "The last sample that occurred before time X."
   - `RoundInward = SpanRoundingMode(RoundUp, RoundDown)`: round the start up
     and the stop down — i.e. shrink the span until both endpoints land on
     samples. This gives *exactly* the samples that occur as instants inside
     the span. Guarantee (from the docstring, src/AlignedSpans.jl:270-276):
     if `mode.start==RoundUp`, the resulting first index's time is inside
     `span`; if `mode.stop==RoundDown`, the resulting last index's time is
     inside `span`. These guarantees are actually checked at runtime — see
     §8 on asserts.

2. **`ConstantSamplesRoundingMode(start_mode)`** — only round the *start*;
   derive the stop index from `start + n_samples(sample_rate,
   duration(span)) - 1`. The point (src/AlignedSpans.jl:324-341): if you feed
   this mode many spans that all have the *same duration*, you always get
   back `AlignedSpan`s with the *same number of samples* — useful for
   windowing/framing code where consistent window length matters more than
   exactly which samples are included. `RoundInward`/`RoundSpanDown` don't
   have this property because the number of samples that land inside a given
   duration can vary by ±1 depending on phase (see the `n_samples` docstring
   and test comment, §5).

3. **`RoundFullyContainedSampleSpans`** — the "sample-as-span" model; see §6.

### Why `RoundEndsDown`/`RoundDown` naming was rejected (PR #9 discussion)

Early naming used `RoundDown`/`RoundEndsDown` for the "both ends down" mode,
but `RoundDown` is already exported by `Base` for single-value rounding
(`round(Int, 1.8, RoundDown)`), and reusing it for "round both ends of an
interval down" was judged a confusing pun (type piracy-adjacent naming, not
literal piracy). The naming went through several iterations in review:
`RoundEndsDown` → `RoundEndpointsDown`/`EndpointRoundingMode` (rejected:
"endpoint" was still ambiguous re: start vs. stop) → final:
`RoundSpanDown`/`SpanRoundingMode`. Small thing, but illustrates that even
naming here required real semantic precision because the domain is subtle.

## 4. Endpoint conventions: closed-closed canonicalization

Internally, all time spans get canonicalized to closed-closed
`Interval{Nanosecond,Closed,Closed}` before any index math happens
(`to_interval` in src/interop.jl:134-143). A `TimeSpan` (closed-open) becomes
closed-closed by subtracting 1ns from the stop. This was **not** the original
implementation — PR #41 replaced an earlier, ad hoc check:

```julia
# removed in PR #41:
if is_stop_exclusive(interval) && mode == RoundDown && iszero(error)
    ...
end
```

which was "a crude and sometimes incorrect version of canonicalizing to
closed-closed intervals" (PR #41 description). Doing the canonicalization
once, up front, in `to_interval`, made all the downstream rounding logic
simpler and fixed a real counting bug (see §7). The tradeoff acknowledged in
the same PR: "it does mean we need +1ns and -1ns here and there, which
obviously can be a source of bugs" — i.e. this is a deliberate, documented
trade of one kind of bug-proneness (ad hoc exclusive/inclusive branching) for
another (careful but localized ±1ns arithmetic), and the localized version
was judged easier to get right and to test.

## 5. `n_samples`: "minimal number of samples in a duration"

`n_samples(sample_rate, duration)` (src/time_index_conversions.jl) answers:
"what is the *minimum* number of samples that could occur in a span of this
duration, regardless of phase/alignment?" It's explicitly a lower bound, not
an exact count for any particular span — the test-suite comment makes this
precise (test/time_index_conversions.jl:117-121):

```julia
# `n` is the *actual* number of samples, given the whole span
# `n_samples(rate, TimeSpans.duration(span))` gives us the minimum
# number of samples of any span of that duration.
# Thus, we should have:
@test n >= n_samples(rate, TimeSpans.duration(span)) >= (n - 1)
```

So actual sample counts can be `n_samples(...)` or `n_samples(...) + 1`
depending on phase alignment — never less, never more than +1. This
off-by-one-depending-on-phase fact is *the* reason
`ConstantSamplesRoundingMode` exists (§3): if you want deterministic window
sizes for framing/windowing code, you can't just use "round inward" per
window, you need to fix the sample count from the duration once and reuse it.

## 6. `RoundFullyContainedSampleSpans`: samples as spans, not instants

Added in PR #38, directly motivated by issue #36 (see §7 for that saga) and
the underlying need: some data (the running example is **hypnograms** —
sleep-stage annotations, typically at 1/30 Hz, i.e. one label per 30-second
epoch) are more naturally modeled as *each sample represents a span of time*
(e.g. "[this epoch's start, next epoch's start)") rather than an instant.

Under this mode, sample `i` corresponds to the closed-open span
`[time_from_index(rate,i), time_from_index(rate,i+1))`, and the rounding
finds the *fully contained* sample-spans within the input span — a stricter
form of "inward" rounding than `RoundInward` (which only requires the sample
*instant* to be inside, not its whole associated span).

Worked example (from the docstring, src/AlignedSpans.jl:146-196): at 1Hz,
input span `[1.5s, 3.5s)` — `RoundInward` includes indices 2 and 3 (their
instants 1s and 2s... wait, actually re-derive: instants at 2s and 3s are
within [1.5,3.5), giving indices 3 and 4). `RoundFullyContainedSampleSpans`
only includes index 3, because only the sample-span `[2s,3s)` is *fully*
contained in `[1.5s,3.5s)` — the spans `[1s,2s)` and `[3s,4s)` are each only
partially overlapping the input.

Implementation note (src/interop.jl:72-113): computed by rounding the raw
stop index down, then checking if the *end* of that sample's span (i.e. one
ns before the *next* sample's start) is still `<= last(interval)`; if not,
decrement by one. There's a comment explaining a subtlety in that check:

```julia
# Note: we don't use `end_of_span_time in interval`, since that could occur if we are before
# the _start_ of the interval, rather than past the end of it.
```

i.e. naively checking interval-membership could give a false positive if the
computed `end_of_span_time` happens to be *before* the interval's start
rather than after its end — a classic "boundary check via containment is
wrong when the value could be out-of-range on *either* side" bug class.

## 7. War story: the float64 sample-rate precision saga (issues #36, #40; PRs #41, #42, #44)

This is the single largest, most instructive thread in the whole repo, and
probably deserves its own docs subsection with the worked numeric examples
reproduced.

### The trigger: issue #36, "`ROUND_INWARD` incorrect"

A user found that `RoundInward` on a span ending at
`08:40:30.000000001` produced an `AlignedSpan` whose `TimeSpan` conversion
ended at `08:41:00`, not `08:40:30`. After investigation (including a
false-alarm "actually I think this is right" self-correction mid-thread),
the conclusion was: `RoundInward` was *behaving as documented*, but its
documented semantics are simply not what you want for "sample-as-span"-style
data (hypnograms) — this is the issue that directly motivated
`RoundFullyContainedSampleSpans` (§6). Quote from the resolution:

> The underlying weirdness, as usual, is that the input span is not
> sample-aligned. What happens when the input is not sample-aligned follows
> specific documented rules, but it is often unintuitive.

### The bug: issue #40, "Unexpected error in `stop_index_from_time`"

Separately, a real *bug* (not just confusing-but-correct behavior) was found:
at 180 Hz, `time_from_index` uses `Float64` division internally
(`nanoseconds_per_sample`), and floating point rounding could produce a
`time_from_index` result that's 1ns *later* than the actual last sample time
it should represent, violating an internal invariant the code asserts. MWE:

```julia
sample_rate = 180
nanoseconds_per_sample(sample_rate)          # 5.555555555555556e6  (inexact float!)
sample_index = 181
(sample_index - 1) * nanoseconds_per_sample(sample_rate)   # 1.0000000000000001e9
ceil(Int, ...)                                              # 1000000001, should be 1000000000
```

This tripped the internal consistency check
(`time_from_index(rate,last_index) <= last(interval)`), which either warned
loudly or errored depending on `AlignedSpans.ASSERTS_ON[]` (see §8) — and,
compounding the confusion, the error-reporting code itself had a bug: a local
variable named `error` shadowed `Base.error`, so *trying to raise the
descriptive error* threw a useless `MethodError: objects of type Nanosecond
are not callable` instead (fixed alongside in PR #41, commit "fix
shadowing"). Lesson embedded in the commit history: don't name local
variables `error` in a package that also wants to call `Base.error`.

### The fix arc: PR #41 → #42 → #44 (rationals all the way)

PR #41 fixed the immediate closed-open canonicalization bug (§4) but the root
cause (float64 imprecision in `nanoseconds_per_sample`/`time_from_index`) was
still open. This spawned a genuinely rigorous numerical-methods investigation
in the PR #41 discussion thread, worth preserving in full because it's a good
model of "how do you validate a numeric algorithm empirically when you don't
have a closed-form correctness proof":

- Set up a **reference/"exact" implementation** using `BigInt`/`Rational{BigInt}`
  arithmetic (via `ceil(Int, (BigInt(...) * BigInt(NS_IN_SEC)) / rate)`), which
  is slow but by-construction exact.
- Tested several candidate fast implementations (`v0`..`v6`) against the exact
  reference across a grid of sample rates (including nasty ones: `180`,
  `4//3`, `1//3`, `1//30`, `44_000`, ...) and sample indices (`1` up to `10^12`).
  Candidates included: `Int64` arithmetic (fails on overflow/inexactness for
  some cases), `Int128` arithmetic, plain `Float64`, and — the eventual
  winner — converting the sample rate to a `Rational` via `rationalize` and
  doing the division in `Int128`/`Rational` arithmetic
  (`cld(Int128(...), rationalize(sample_rate))`), which matched the exact
  reference on *every* test case in the grid.
- This "rationalize the float" trick was explicitly flagged by its author as
  "gross... very do-what-I-mean-not-what-I-say," i.e. an acknowledged
  hack/pragmatic choice, not a principled derivation — but empirically it
  worked and was judged "not that slow" (benchmarked at ~500ns-1µs vs ~3.5ns
  for the naive float division — a 100-200x slowdown in isolation, but a much
  smaller relative slowdown in realistic end-to-end workloads:
  ~0.13s → ~2.35s for building 10^6 spans in one microbenchmark, later
  brought back down to ~0.17s by special-casing integer sample rates).
- **The actual resolution (PR #44) was more fundamental than "rationalize
  when needed":** stop treating `sample_rate` as a `Float64` at the
  `AlignedSpan` *struct* level entirely. `AlignedSpan.sample_rate` is now
  typed `Union{Int64,Rational{Int64}}` (src/AlignedSpans.jl:213-214), with a
  `convert_sample_rate` normalizer (src/AlignedSpans.jl:198-206) that:
  - keeps exact integers as `Int64`,
  - keeps values that are already `Rational` as `Rational{Int64}`,
  - and calls `rationalize(Int64, x)` on anything else (e.g. a `Float64` like
    `1/30` or `128.33`) to get the closest rational approximation with a
    bounded-size numerator/denominator.
  This means the "rationalize" conversion happens **once**, at
  `AlignedSpan` construction, rather than being repeated inside every
  `time_from_index`/`index_from_time` call — a meaningful performance win
  over the PR #41 approach, and it lets users who *know* their exact rational
  rate (e.g. hypnograms at `1//30`) pass it directly and skip any conversion
  or approximation entirely.

### Explicitly acknowledged: this is a breaking-ish change, tolerated deliberately

Changing `sample_rate`'s stored type from implicitly-`Float64` to
`Union{Int64,Rational{Int64}}` is technically within the documented public
API contract (no field type was ever promised) but could still surprise
downstream code that assumed `Float64`. The maintainers discussed this
explicitly (PR #44 comments) and chose to ship it anyway:

> On the one hand this is a pretty load bearing library and so that suggests
> erring on the side of caution; on the other hand, shepherding 1,000,000
> internal projects through this upgrade could be a real pain and anything
> that is really critical should be using a pinned manifest anyway so...
> YOLO IMO

This is a good example for the docs of a real engineering tradeoff being made
consciously and explained, not swept under the rug — matches the "deviations
must be explicit, well-documented, and well-motivated" house style.

## 8. The assert/warn mechanism (`ASSERTS_ON`)

Several places in `src/interop.jl` compute a rounded index and then
*independently verify* that the round-trip respects the invariant the
docstring promises (e.g. "if we rounded up, the result should really be
`>=` the original time"). If the check fails:

- if `AlignedSpans.ASSERTS_ON[]` is `true` (default: `false`,
  src/AlignedSpans.jl:14): raise a hard `error(msg)`.
- otherwise: `@warn msg maxlog=100` (rate-limited so pathological inputs
  don't spam logs) and return the (possibly wrong-by-1) index anyway.

Rationale (PR #37, which added most of these): "I believe these should never
fire by construction. I'm not 100% sure if we want them or not; if they fire
there is probably a logic bug in AlignedSpans, but do we want that to bring
down some production code?" — i.e. this is a deliberate soft-fail-by-default
posture for a library embedded in production data pipelines: prefer a loud
warning (with a direct link to file an issue) over crashing a batch job,
while still giving developers/CI a way to turn on hard failures
(`ASSERTS_ON[] = true`) for testing. The warnings are intentionally excluded
from coverage requirements since (if the invariants hold) they're unreachable
in tests — noted directly in the PR #37 description.

These are exactly the checks that caught the issue #40 bug in the first
place — a good real-world justification for "defensive asserts on invariants
you believe are unconditionally true" even in performance-sensitive code.

## 9. Miscellaneous but real design decisions worth documenting

- **Negative / out-of-range indices are allowed** (issue #15, PR #16). Original
  code copied `sample_time >= 0` validation straight from
  `TimeSpans.index_from_time`, but that check doesn't actually make sense for
  `AlignedSpans`: an `AlignedSpan` is fundamentally "a sample-rate-aligned
  span of *time*," not something necessarily tied to an actual, existing
  `Samples` object with a known start/duration. Quote: "since spans can be
  relative and what they are relative to can change, having spans be tied to
  specific samples doesn't really make sense and is impractical and
  unhelpful." (Actually indexing into a concrete `Samples` object with an
  out-of-range `AlignedSpan` still throws `BoundsError` at that point, as
  tested in test/interop.jl — the *construction* of the span is what's
  intentionally permissive.)

- **`Intervals.jl` over `TimeSpans.jl` internals** (PR #2). Originally
  (PR #1) `AlignedSpan → TimeSpan` conversion was hacked in by adding 1ns to
  fake an exclusive endpoint, but this wasn't robust across `TimeSpans.jl`
  versions (v0.2 vs v0.3 had incompatible internal representations, and v0.3
  wasn't Onda-compatible yet at the time). The fix was to depend on the more
  general `Intervals.jl` for representing arbitrary open/closed endpoints
  internally, and treat `TimeSpans` compatibility as one supported interface
  among others (Onda indices, JSON, Arrow) rather than a load-bearing
  internal dependency. This is why `to_interval` exists as a dispatch point
  (§4) — it's the seam between "whatever time-span-like type the user
  handed us" and the package's real internal currency, closed-closed
  `Interval{Nanosecond}`.

- **`AlignedSpan(::AlignedSpan)` / composing constructors** (PR #11). Found
  via a downstream package (`DataFrameIntervals.jl`) exercising an edge case;
  fixed together with de-duplicating a copy of the same helper that had
  drifted between `runtests.jl` and `interop.jl` — a reminder that
  test-helper duplication is itself a bug-prone pattern.

- **`Onda.column_arguments` dispatch, not a round-trip through `TimeSpan`**
  (PR #2). Indexing `samples[:, aligned_span]` is implemented directly via
  `Onda.column_arguments(::Samples, ::AlignedSpan) = indices(span)` — i.e.
  "time → index → index" (`TimeSpan → AlignedSpan → indices`),
  deliberately avoiding the "time → index → time → index" round-trip
  (`TimeSpan → AlignedSpan → TimeSpan → indices`) that a more
  generic/naive integration would have required. The PR author flags this
  explicitly as a design win: fewer representation changes = fewer chances
  for rounding to introduce drift.
  It also enforces `Float64(span.sample_rate) == samples.info.sample_rate`
  and throws an `ArgumentError` on mismatch (tested in test/interop.jl) —
  cross-checked at the interop boundary rather than trusted implicitly.

- **`consecutive_subspans` / `consecutive_overlapping_subspans`**
  (`keep_last` semantics, PR #19, issue #20). `consecutive_subspans` splits
  a span into equal-size (except possibly last) windows; `keep_last=false`
  variant added specifically so the two functions could share consistent
  semantics for the "windowing" (non-overlapping) case. Extending
  `keep_last=true` semantics to the *overlapping* case was explicitly
  deferred (issue #20, still open) because it's genuinely ambiguous what a
  "partial last hop" should mean once windows overlap — quote: "if there's 8
  fold overlap, the last 7 will all be shorter than usual, and the last one
  will be 1 sample long. But it's a bit weird. I'd rather leave that until
  someone needs it." — an example of consciously not solving a problem
  nobody has hit yet, and leaving a documented issue as the paper trail
  (per the "manage technical debt via issues" house principle).

- **`StepRange` interop is a documented "this is not great" escape hatch**
  (test/interop.jl comments): `Base.StepRange(::AlignedSpan)` exists mainly
  "to show we could interop with `StepRange`, which is another contender for
  a TimeSpans alternative," but the code comment admits "the rounding here is
  not ideal," and the round-trip test tolerates `rtol = 1e-7` on the sample
  rate with the comment "annoyingly imprecise." Not a load-bearing part of
  the API; more a proof-of-concept / compatibility gesture.

- **`translate` was deliberately *not* added as a method** (issue #12,
  still open). A `TimeSpans.translate(::AlignedSpan, ::TimePeriod)`
  implementation was sketched (shift both indices by
  `n_samples(rate, abs(t)) * sign(t)`, preserving exact sample count — unlike
  the generic `TimeSpans` fallback which shifts the time values directly and
  can come back with a different sample count after re-rounding) but as of
  these notes it hasn't been merged; a second user independently hit the same
  confusion ("shifting a 'template' AlignedSpan around... got confused when
  the resulting duration was off"), suggesting this is a real, recurring
  footgun worth covering in the docs even before/regardless of whether the
  `translate` method itself lands.

## 10. Threads that are open questions / deliberately deferred (good "known limitations" material)

- Issue #20: `keep_last` for `consecutive_overlapping_subspans` — deferred,
  ambiguous semantics under overlap.
- Issue #22: `merge_aligned_spans` — sketched as roughly
  `AlignedSpan.(sample_rate, merge_spans(f, aligned_spans))` but more
  efficient / sample-rate-checked; not implemented as of these notes.
- Issue #12: `TimeSpans.translate` for `AlignedSpan` — sketched, not merged;
  the generic `TimeSpans` fallback exists but round-trips through `TimeSpan`
  and can silently change the sample count.

## 11. Source map (for writing docs with accurate line references)

- `src/AlignedSpans.jl` — struct definition, rounding-mode types, the three
  `AlignedSpan(sample_rate, span, mode)` constructors, and their extensive
  docstrings (these docstrings already contain most of the worked examples;
  the docs rewrite should probably promote/expand these rather than
  duplicate them from scratch).
- `src/time_index_conversions.jl` — `time_from_index`, `index_from_time`,
  `n_samples`; the tiny file where all the "instant in time" math actually
  lives (32 lines, but see §7 for how much design/debate is behind those 32
  lines).
- `src/interop.jl` — `to_interval` (the closed-closed canonicalization seam,
  §4), `start_index_from_time`/`stop_index_from_time` for `Interval`s (with
  the assert/warn checks, §8), the `RoundFullyContainedSampleSpans` stop-index
  logic (§6), Onda/TimeSpans/JSON/Arrow interop glue.
- `src/utilities.jl` — `indices`, `n_samples(::AlignedSpan)`,
  `consecutive_subspans`, `consecutive_overlapping_subspans`.
- `test/time_index_conversions.jl` — has a from-scratch `naive_index_from_time`
  (brute-force stepping in `Rational{BigInt}`) used as an independent oracle
  to test `index_from_time` against; good pedagogical material since it's a
  second, obviously-correct-but-slow implementation of the same idea.
- `test/interop.jl` — round-tripping tests across sample rates including the
  deliberately nasty `128.33`, plus the `StepRange` proof-of-concept.
- `docs/src/index.md` — existing docs already contain the core "Motivation"
  example (plotting misalignment) and the index→time convention
  writeup; the "Note on roundtripping" section header exists but is
  currently *empty* (docs/src/index.md line ~64-66) — that's a concrete gap
  to fill using §2/§7 material.


</details>

Then guided it to add the decision journal, examples, and updates while matching tone/style. I think the concepts are still hard to explain/understand but maybe this is a step in the right direction. My motivation is also that I think we will end up reimplementing some of this in python or typescript, so I want the logic/decisions/examples to be clear because there are a lot of edge cases and traps.