### PR TITLE
add little illustrations for each example in the docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /Manifest.toml
 docs/Manifest.toml
 docs/build
+docs/src/assets/generated

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,8 +2,10 @@
 AlignedSpans = "72438786-fd5d-49ef-8843-650acbdfe662"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Onda = "e853f5be-6863-11e9-128d-476edb89bfb5"
 TimeSpans = "bb34ddd2-327f-4c4a-bfb0-c98fc494ece1"
 
 [compat]
 Documenter = "1"
+JSON = "0.21, 1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,9 +1,16 @@
 using AlignedSpans
 using Documenter
 
+# We pregenerate some JSON containing time-index conversions
+# to use in our little js widget to display in the docs.
+include("widget_data.jl")
+
 makedocs(; modules=[AlignedSpans],
          sitename="AlignedSpans",
          authors="Beacon Biosignals, Inc.",
+         format=Documenter.HTML(; assets=["assets/aligned-spans-widget.css",
+                                           "assets/generated/aligned-spans-widget-data.js",
+                                           "assets/aligned-spans-widget.js"]),
          pages=["Introduction" => "index.md",
                 "Examples" => "examples.md",
                 "API Documentation" => "API.md",

--- a/docs/src/assets/aligned-spans-widget.css
+++ b/docs/src/assets/aligned-spans-widget.css
@@ -1,0 +1,122 @@
+.aligned-spans-widget {
+    border: 1px solid rgba(128, 128, 128, 0.35);
+    border-radius: 6px;
+    padding: 0.75rem 1rem 1rem 1rem;
+    margin: 1rem 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    overflow-x: auto;
+}
+
+.asw-figure {
+    position: relative;
+    min-width: 420px;
+    height: 150px;
+    margin: 0.5rem 0 0.25rem 0;
+}
+
+.asw-input-span {
+    position: absolute;
+    top: 0;
+    height: 18px;
+    background: currentColor;
+    opacity: 0.12;
+    border-left: 2px solid currentColor;
+    border-right: 1px dashed currentColor;
+}
+
+.asw-input-span-label {
+    position: absolute;
+    top: 20px;
+    font-size: 0.7rem;
+    opacity: 0.7;
+    white-space: nowrap;
+}
+
+.asw-span-band {
+    position: absolute;
+    top: 44px;
+    height: 34px;
+    border-radius: 3px;
+    opacity: 0.28;
+}
+
+.asw-track {
+    position: absolute;
+    top: 60px;
+    left: 0;
+    right: 0;
+    height: 1px;
+    background: currentColor;
+    opacity: 0.4;
+}
+
+.asw-dot {
+    position: absolute;
+    top: 61px;
+    width: 11px;
+    height: 11px;
+    margin-left: -5.5px;
+    margin-top: -5.5px;
+    border-radius: 50%;
+    background: rgba(128, 128, 128, 0.55);
+    box-sizing: border-box;
+    border: 1.5px solid currentColor;
+}
+
+.asw-index-label {
+    position: absolute;
+    top: 70px;
+    transform: translateX(-50%);
+    font-size: 0.7rem;
+    opacity: 0.85;
+    white-space: nowrap;
+}
+
+.asw-tick-label {
+    position: absolute;
+    top: 96px;
+    transform: translateX(-50%);
+    font-size: 0.65rem;
+    opacity: 0.65;
+    white-space: nowrap;
+}
+
+.asw-bracket {
+    position: absolute;
+    height: 3px;
+    border-radius: 2px;
+}
+
+.asw-bracket-label {
+    position: absolute;
+    font-size: 0.7rem;
+    white-space: nowrap;
+}
+
+.asw-legend {
+    font-size: 0.8rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.15rem 1rem;
+    margin-top: 0.25rem;
+}
+
+.asw-legend-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.asw-swatch {
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    display: inline-block;
+    flex: none;
+}
+
+.asw-note {
+    font-size: 0.75rem;
+    opacity: 0.7;
+    margin-top: 0.35rem;
+}

--- a/docs/src/assets/aligned-spans-widget.js
+++ b/docs/src/assets/aligned-spans-widget.js
@@ -1,0 +1,272 @@
+// Renders the `.aligned-spans-widget` elements embedded in the AlignedSpans.jl
+// docs. This file does no rounding/time-conversion math of its own: every
+// number it draws (sample times, resulting index ranges, resulting
+// TimeSpans) comes from `window.ALIGNED_SPANS_SCENARIOS`, generated at
+// doc-build time by docs/widget_data.jl using the real AlignedSpans package.
+// This file only positions and colors boxes based on those numbers.
+(function () {
+    "use strict";
+
+    var NAMED_COLORS = {
+        RoundSpanDown: "#2b6cb0",
+        RoundInward: "#c05621",
+        RoundFullyContainedSampleSpans: "#2f855a",
+        ConstantSamplesRoundingMode: "#805ad5",
+        given: "#4a5568",
+        original: "#2b6cb0",
+        shifted: "#c05621",
+    };
+    var PALETTE = ["#2b6cb0", "#c05621", "#2f855a", "#805ad5", "#b83280", "#b7791f"];
+
+    function colorFor(groupName, indexInList, listLength) {
+        if (listLength > 1) {
+            return PALETTE[indexInList % PALETTE.length];
+        }
+        return NAMED_COLORS[groupName] || PALETTE[0];
+    }
+
+    function isSpanStyle(groupName) {
+        return /FullyContained/i.test(groupName);
+    }
+
+    function formatNs(ns) {
+        var s = ns / 1e9;
+        var str = s.toFixed(3).replace(/\.?0+$/, "");
+        if (str === "" || str === "-") {
+            str = "0";
+        }
+        return str + "s";
+    }
+
+    function el(tag, className, style) {
+        var e = document.createElement(tag);
+        if (className) e.className = className;
+        if (style) {
+            for (var k in style) {
+                if (Object.prototype.hasOwnProperty.call(style, k)) {
+                    e.style[k] = style[k];
+                }
+            }
+        }
+        return e;
+    }
+
+    // Builds the list of {name, range, color} entries to draw, from the
+    // scenario's `results` and the requested group names.
+    function activeRanges(scenario, groupNames) {
+        var out = [];
+        groupNames.forEach(function (name) {
+            var list = scenario.results[name];
+            if (!list) return;
+            list.forEach(function (range, i) {
+                out.push({
+                    name: name,
+                    label: list.length > 1 ? name + " #" + (i + 1) : name,
+                    range: range,
+                    color: colorFor(name, i, list.length),
+                    spanStyle: isSpanStyle(name),
+                });
+            });
+        });
+        return out;
+    }
+
+    function drawFigure(scenario, groupNames) {
+        var window_ = scenario.window;
+        var ranges = activeRanges(scenario, groupNames);
+
+        var minT = Math.min.apply(
+            null,
+            window_.map(function (w) {
+                return w.time_ns;
+            })
+        );
+        var maxT = Math.max.apply(
+            null,
+            window_.map(function (w) {
+                return w.time_ns;
+            })
+        );
+        if (scenario.input_span) {
+            minT = Math.min(minT, scenario.input_span.start_ns);
+            maxT = Math.max(maxT, scenario.input_span.stop_ns);
+        }
+        ranges.forEach(function (r) {
+            minT = Math.min(minT, r.range.timespan_start_ns);
+            maxT = Math.max(maxT, r.range.timespan_stop_ns);
+        });
+        if (maxT === minT) {
+            maxT = minT + 1;
+        }
+
+        var pad = 24;
+        var width = Math.max(420, window_.length * 46);
+        var innerWidth = width - 2 * pad;
+
+        function xFor(t) {
+            return pad + ((t - minT) / (maxT - minT)) * innerWidth;
+        }
+
+        var figure = el("div", "asw-figure", { width: width + "px" });
+
+        // Input span band.
+        if (scenario.input_span) {
+            var x0 = xFor(scenario.input_span.start_ns);
+            var x1 = xFor(scenario.input_span.stop_ns);
+            var band = el("div", "asw-input-span", {
+                left: x0 + "px",
+                width: Math.max(2, x1 - x0) + "px",
+            });
+            figure.appendChild(band);
+            var spanLabel = el("div", "asw-input-span-label", { left: x0 + "px" });
+            spanLabel.textContent =
+                "input span: [" + formatNs(scenario.input_span.start_ns) + ", " + formatNs(scenario.input_span.stop_ns) + ")";
+            figure.appendChild(spanLabel);
+        }
+
+        // Sample-as-span bands (e.g. RoundFullyContainedSampleSpans).
+        var byIndex = {};
+        window_.forEach(function (w) {
+            byIndex[w.index] = w.time_ns;
+        });
+        ranges
+            .filter(function (r) {
+                return r.spanStyle;
+            })
+            .forEach(function (r) {
+                for (var i = r.range.first_index; i <= r.range.last_index; i++) {
+                    if (byIndex[i] === undefined || byIndex[i + 1] === undefined) continue;
+                    var bx0 = xFor(byIndex[i]);
+                    var bx1 = xFor(byIndex[i + 1]);
+                    var b = el("div", "asw-span-band", {
+                        left: bx0 + "px",
+                        width: Math.max(2, bx1 - bx0) + "px",
+                        background: r.color,
+                        borderLeft: "2px solid " + r.color,
+                    });
+                    figure.appendChild(b);
+                }
+            });
+
+        // Axis track.
+        figure.appendChild(el("div", "asw-track"));
+
+        // Dots + index/time labels.
+        function colorForIndex(idx) {
+            var c = null;
+            ranges.forEach(function (r) {
+                if (idx >= r.range.first_index && idx <= r.range.last_index) {
+                    c = r.color;
+                }
+            });
+            return c;
+        }
+        window_.forEach(function (w) {
+            var x = xFor(w.time_ns);
+            var c = colorForIndex(w.index);
+            var dot = el("div", "asw-dot", { left: x + "px" });
+            if (c) {
+                dot.style.background = c;
+                dot.style.borderColor = c;
+            }
+            figure.appendChild(dot);
+
+            var idxLabel = el("div", "asw-index-label", { left: x + "px" });
+            idxLabel.textContent = String(w.index);
+            figure.appendChild(idxLabel);
+
+            var tLabel = el("div", "asw-tick-label", { left: x + "px" });
+            tLabel.textContent = formatNs(w.time_ns);
+            figure.appendChild(tLabel);
+        });
+
+        // Result brackets (the resulting TimeSpan for each active group).
+        // Each group gets its own row, tall enough that the label text of one
+        // row doesn't run into the bracket line of the next.
+        var BRACKET_ROW_HEIGHT = 34;
+        var BRACKET_FIRST_Y = 116;
+        ranges.forEach(function (r, i) {
+            var bx0 = xFor(r.range.timespan_start_ns);
+            var bx1 = xFor(r.range.timespan_stop_ns);
+            var y = BRACKET_FIRST_Y + i * BRACKET_ROW_HEIGHT;
+            var bracket = el("div", "asw-bracket", {
+                left: bx0 + "px",
+                width: Math.max(2, bx1 - bx0) + "px",
+                top: y + "px",
+                background: r.color,
+            });
+            figure.appendChild(bracket);
+            var label = el("div", "asw-bracket-label", {
+                left: bx0 + "px",
+                top: y + 6 + "px",
+                color: r.color,
+            });
+            label.textContent =
+                r.label + ": [" + formatNs(r.range.timespan_start_ns) + ", " + formatNs(r.range.timespan_stop_ns) + ")";
+            figure.appendChild(label);
+        });
+
+        figure.style.height = BRACKET_FIRST_Y + ranges.length * BRACKET_ROW_HEIGHT + 10 + "px";
+
+        return { figure: figure, ranges: ranges };
+    }
+
+    function drawLegend(scenario, ranges) {
+        var legend = el("div", "asw-legend");
+        var rate = el("div", "asw-legend-item");
+        rate.innerHTML = "<strong>sample rate:</strong>&nbsp;" + scenario.sample_rate + " Hz";
+        legend.appendChild(rate);
+        ranges.forEach(function (r) {
+            var item = el("div", "asw-legend-item");
+            var swatch = el("span", "asw-swatch", { background: r.color });
+            item.appendChild(swatch);
+            var text = el("span");
+            text.textContent =
+                r.label + ": indices " + r.range.first_index + ":" + r.range.last_index;
+            item.appendChild(text);
+            legend.appendChild(item);
+        });
+        return legend;
+    }
+
+    function render(container, scenarioName, groupNames) {
+        var data = window.ALIGNED_SPANS_SCENARIOS || {};
+        var scenario = data[scenarioName];
+        var target = container.querySelector(".asw-render-target");
+        target.innerHTML = "";
+        if (!scenario) {
+            target.textContent = "Unknown scenario: " + scenarioName;
+            return;
+        }
+        if (!groupNames || groupNames.length === 0) {
+            groupNames = Object.keys(scenario.results);
+        }
+        var built = drawFigure(scenario, groupNames);
+        target.appendChild(built.figure);
+        target.appendChild(drawLegend(scenario, built.ranges));
+    }
+
+    function initStatic(container) {
+        var scenarioName = container.getAttribute("data-scenario");
+        var groupNames = (container.getAttribute("data-results") || "")
+            .split(",")
+            .map(function (s) {
+                return s.trim();
+            })
+            .filter(Boolean);
+        var target = el("div", "asw-render-target");
+        container.appendChild(target);
+        render(container, scenarioName, groupNames);
+    }
+
+    function init() {
+        var widgets = document.querySelectorAll(".aligned-spans-widget");
+        widgets.forEach(initStatic);
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", init);
+    } else {
+        init();
+    }
+})();

--- a/docs/src/decisions.md
+++ b/docs/src/decisions.md
@@ -22,6 +22,10 @@ aligned = AlignedSpan(1, 2:3) # indices 2 and 3 are both included
 TimeSpan(aligned) # TimeSpans.jl spans exclude their right endpoint: [1s, 3s)
 ```
 
+```@raw html
+<div class="aligned-spans-widget" data-scenario="index-to-time" data-results="given"></div>
+```
+
 ## The index -> time conversion convention
 
 For `TimeSpans.start`/`TimeSpans.stop`, we use `start(span) = time_from_index(sample_rate, first_index)` and `stop(span) = time_from_index(sample_rate, last_index + 1)` ([PR #9](https://github.com/beacon-biosignals/AlignedSpans.jl/pull/9)). We considered instead using the time of the last sample plus one nanosecond, but rejected it for two reasons: durations would come out one sample period short of what's expected (5 samples at 1Hz would have duration `4s + 1ns` instead of `5s`), and two adjacent `AlignedSpan`s would not map to two adjacent `TimeSpan`s (there'd be a gap of almost one sample period between them). Taking the stop as the time of the sample after the last one avoids both problems, and matches the inclusive-inclusive convention of Julia's integer indices to the inclusive-exclusive convention Onda/TimeSpans use.
@@ -36,6 +40,10 @@ aligned = AlignedSpan(1, 2:3) # samples 2 and 3, at 1Hz
 TimeSpan(aligned) # starts when sample 2 occurs, stops when sample 4 would occur
 
 duration(aligned) # 2 samples at 1Hz is a sensible 2 seconds, not `1s + 1ns`
+```
+
+```@raw html
+<div class="aligned-spans-widget" data-scenario="index-to-time" data-results="given"></div>
 ```
 
 ## Sample rate representation: floating point vs. rational
@@ -72,6 +80,10 @@ AlignedSpan(1, span, RoundSpanDown) # rounds both endpoints down: 1.5s -> 1s, 2.
 AlignedSpan(1, span, RoundInward) # shrinks until both endpoints land on samples
 ```
 
+```@raw html
+<div class="aligned-spans-widget" data-scenario="decisions-modes-example" data-results="RoundSpanDown,RoundInward"></div>
+```
+
 Naming `RoundSpanDown` took a few iterations ([PR #9](https://github.com/beacon-biosignals/AlignedSpans.jl/pull/9)). We initially called it `RoundEndsDown`, with an `EndpointRoundingMode` type, but `RoundDown` is already exported by `Base` for rounding a single value, and reusing it as part of a name for rounding both ends of an interval was judged confusing. We tried `RoundEndpointsDown`, but "endpoint" was still ambiguous about which endpoint. We settled on `SpanRoundingMode`/`RoundSpanDown`, which reads as "the mode that rounds the span down."
 
 `RoundFullyContainedSampleSpans` was added later ([PR #38](https://github.com/beacon-biosignals/AlignedSpans.jl/pull/38)), after `RoundInward` produced a result that a user found surprising ([issue #36](https://github.com/beacon-biosignals/AlignedSpans.jl/issues/36)): rounding a span with `RoundInward` at 1/30Hz could produce an `AlignedSpan` that, once converted back to a `TimeSpan`, extended well past the original input. `RoundInward` was doing exactly what it's documented to do — including every sample whose instant occurs within the span — but that's not the answer you want if you think of each sample as covering a span of time, as with a hypnogram. Rather than changing `RoundInward`'s semantics, we added `RoundFullyContainedSampleSpans` as a separate mode for that case.
@@ -100,6 +112,10 @@ using AlignedSpans
 AlignedSpan(1, -5:10) # allowed: this span starts before index 1 of some signal
 ```
 
+```@raw html
+<div class="aligned-spans-widget" data-scenario="out-of-range-raw" data-results="given"></div>
+```
+
 `consecutive_subspans` supports `keep_last=false` so its behavior can match `consecutive_overlapping_subspans` ([PR #19](https://github.com/beacon-biosignals/AlignedSpans.jl/pull/19)), but we haven't extended `keep_last=true` semantics to the overlapping case ([issue #20](https://github.com/beacon-biosignals/AlignedSpans.jl/issues/20)): with overlapping windows, it's not obvious what a shorter last window should mean (if there's 8-fold overlap, do the last 7 windows all get shorter, or just the very last one?). We're leaving this until someone has a concrete use case.
 
 ```@repl decisions_keep_last
@@ -108,10 +124,26 @@ using AlignedSpans
 span = AlignedSpan(1, 1:10)
 
 collect(consecutive_subspans(span, 3)) # keep_last=true (default): last window is shorter
+```
 
+```@raw html
+<div class="aligned-spans-widget" data-scenario="windowing" data-results="windows"></div>
+```
+
+```@repl decisions_keep_last
 collect(consecutive_subspans(span, 3; keep_last=false)) # drops the short last window instead
+```
 
+```@raw html
+<div class="aligned-spans-widget" data-scenario="windowing" data-results="windows-keep-last-false"></div>
+```
+
+```@repl decisions_keep_last
 collect(consecutive_overlapping_subspans(span, 3, 2)) # overlapping windows only ever come in the "keep_last=false" style
+```
+
+```@raw html
+<div class="aligned-spans-widget" data-scenario="windowing" data-results="windows-overlapping"></div>
 ```
 
 We've sketched, but not implemented, `TimeSpans.translate` for `AlignedSpan` ([issue #12](https://github.com/beacon-biosignals/AlignedSpans.jl/issues/12)) and `merge_aligned_spans` ([issue #22](https://github.com/beacon-biosignals/AlignedSpans.jl/issues/22)). The generic `TimeSpans.translate` fallback already works for `AlignedSpan`s, but shifts the time values directly and can change the resulting sample count; an `AlignedSpan`-specific implementation would shift by a number of samples instead, preserving the count:
@@ -126,6 +158,10 @@ n_samples(span)
 shifted = TimeSpans.translate(span, Second(1)) # the generic fallback shifts the *time* and returns a TimeSpan
 
 n_samples(AlignedSpan(span.sample_rate, shifted, RoundSpanDown)) # re-rounding isn't guaranteed to match n_samples(span)
+```
+
+```@raw html
+<div class="aligned-spans-widget" data-scenario="shifting" data-results="original,shifted"></div>
 ```
 
 We may add this in a future release of AlignedSpans.jl.

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -31,6 +31,10 @@ in_span = AlignedSpan(1, span, RoundInward)
 n_samples(in_span)
 ```
 
+```@raw html
+<div class="aligned-spans-widget" data-scenario="eeg-onda-indexing" data-results="RoundSpanDown,RoundInward"></div>
+```
+
 ## Hypnograms and other span-like samples
 
 Some signals, like hypnograms, are more naturally thought of as a sequence of spans rather than a sequence of instants: each sample summarizes some region of time (e.g. a 30 second sleep-stage epoch) rather than being measured at a single instant. For these, `RoundFullyContainedSampleSpans` is usually a better fit than `RoundInward`.
@@ -53,7 +57,11 @@ Compare this to rounding the same `input` with `RoundInward`:
 AlignedSpan(sample_rate, input, RoundInward)
 ```
 
-`RoundInward` includes both the sample at 00:00 and the sample at 00:30, since both occur within `input`. `RoundFullyContainedSampleSpans` includes only the sample at 00:00, since `input` doesn't fully contain the sample-span from 00:30 to 01:00.
+`RoundInward` includes both the sample at 00:00 and the sample at 00:30, since both occur within `input`. `RoundFullyContainedSampleSpans` includes only the sample at 00:00, since `input` doesn't fully contain the sample-span from 00:30 to 01:00. The filled blocks below are the sample-spans that `RoundFullyContainedSampleSpans` reasons about; the dots are the sample instants that `RoundInward` reasons about:
+
+```@raw html
+<div class="aligned-spans-widget" data-scenario="rounding-grows-span" data-results="RoundInward,RoundFullyContainedSampleSpans"></div>
+```
 
 ## Getting a consistent number of samples across spans
 
@@ -64,21 +72,33 @@ using TimeSpans, AlignedSpans, Dates
 
 sample_rate = 3
 
-span1 = TimeSpan(Millisecond(100), Millisecond(1100))
-span2 = TimeSpan(Millisecond(200), Millisecond(1200))
-
-n_samples(AlignedSpan(sample_rate, span1, RoundInward))
-n_samples(AlignedSpan(sample_rate, span2, RoundInward))
+span1 = TimeSpan(Millisecond(0), Millisecond(700))
+span2 = TimeSpan(Millisecond(100), Millisecond(800))
 ```
 
-Both spans have the same duration, but rounding inward can give a different number of samples depending on alignment. Using `ConstantSamplesRoundingMode` instead:
+For `span1`:
 
 ```@repl windows
+n_samples(AlignedSpan(sample_rate, span1, RoundInward))
 n_samples(AlignedSpan(sample_rate, span1, ConstantSamplesRoundingMode(RoundDown)))
+```
+
+```@raw html
+<div class="aligned-spans-widget" data-scenario="constant-samples-1" data-results="RoundInward,ConstantSamplesRoundingMode"></div>
+```
+
+`span2` has the same duration as `span1`, but starts 100ms later, which changes how it lines up with the sample rate:
+
+```@repl windows
+n_samples(AlignedSpan(sample_rate, span2, RoundInward))
 n_samples(AlignedSpan(sample_rate, span2, ConstantSamplesRoundingMode(RoundDown)))
 ```
 
-now both spans have the same number of samples.
+```@raw html
+<div class="aligned-spans-widget" data-scenario="constant-samples-2" data-results="RoundInward,ConstantSamplesRoundingMode"></div>
+```
+
+`RoundInward` gives `span1` 3 samples but `span2` only 2, even though they have the same duration; `ConstantSamplesRoundingMode` gives both 2.
 
 ## Splitting a span into fixed-size or sliding windows
 
@@ -90,13 +110,31 @@ using AlignedSpans
 span = AlignedSpan(1, 1:10) # 10 samples at 1Hz
 
 collect(consecutive_subspans(span, 3)) # windows of 3 samples; the last one may be shorter
+```
 
-collect(consecutive_subspans(span, 3; keep_last=false)) # drop the short last window instead
+```@raw html
+<div class="aligned-spans-widget" data-scenario="windowing" data-results="windows"></div>
+```
 
+Pass `keep_last=false` to drop that short last window instead, if your downstream code requires every window to have exactly the same number of samples:
+
+```@repl chunking
+collect(consecutive_subspans(span, 3; keep_last=false))
+```
+
+```@raw html
+<div class="aligned-spans-widget" data-scenario="windowing" data-results="windows-keep-last-false"></div>
+```
+
+`consecutive_overlapping_subspans` gives sliding windows with a fixed hop between them; it only supports the `keep_last=false` style, since it's not obvious what a partial window should mean once windows overlap:
+
+```@repl chunking
 collect(consecutive_overlapping_subspans(span, 3, 2)) # windows of 3 samples, hopping by 2
 ```
 
-Use `keep_last=false` if your downstream code requires every window to have exactly the same number of samples; use the default `keep_last=true` if you'd rather keep every sample, even if the last window ends up shorter. `consecutive_overlapping_subspans` only supports the `keep_last=false` style, since it's not obvious what a partial window should mean once windows overlap.
+```@raw html
+<div class="aligned-spans-widget" data-scenario="windowing" data-results="windows-overlapping"></div>
+```
 
 ## Spans that start before or run past your recording
 
@@ -108,10 +146,18 @@ using AlignedSpans, TimeSpans, Dates
 AlignedSpan(1238, TimeSpan(Nanosecond(-32), Nanosecond(2)), RoundSpanDown) # the input TimeSpan starts before time 0
 ```
 
-as well as constructing a span directly from out-of-range indices:
+```@raw html
+<div class="aligned-spans-widget" data-scenario="out-of-range-timespan" data-results="RoundSpanDown"></div>
+```
+
+The same applies to constructing a span directly from out-of-range indices:
 
 ```@repl outofrange
 AlignedSpan(1, -5:10) # starts 5 samples before index 1 of some signal
+```
+
+```@raw html
+<div class="aligned-spans-widget" data-scenario="out-of-range-raw" data-results="given"></div>
 ```
 
 Indexing a span like this into an actual `Samples` object raises a `BoundsError` once you try, but constructing the `AlignedSpan` itself doesn't require that a signal covering the whole span already exists.
@@ -133,6 +179,10 @@ n_samples(shifted) == n_samples(span)
 ```
 
 `TimeSpans.translate(span, Second(1))` also works, but it shifts the underlying time and then re-rounds, which isn't guaranteed to preserve the number of samples. This may be improved in subsequent releases of AlignedSpans.jl.
+
+```@raw html
+<div class="aligned-spans-widget" data-scenario="shifting" data-results="original,shifted"></div>
+```
 
 ## Computing sample counts from compound durations
 
@@ -178,6 +228,10 @@ samples[:, AlignedSpan(sample_rate, span, RoundSpanDown)] # matches samples[:, s
 
 ```@repl onda_indexing
 samples[:, AlignedSpan(sample_rate, span, RoundInward)] # does not match: a different set of samples
+```
+
+```@raw html
+<div class="aligned-spans-widget" data-scenario="eeg-onda-indexing" data-results="RoundSpanDown,RoundInward"></div>
 ```
 
 If you need to keep track of exactly which span of time your extracted samples correspond to (for example, to plot them against the correct time axis), construct the `AlignedSpan` with `RoundSpanDown` first, and index with that instead of the original `TimeSpan`:

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -41,7 +41,13 @@ Index       1   [2    3]    4     5
 Time (s)    0   [1    2     3)    4
 ```
 
-This choice of conversion matches the inclusive-inclusive indexing of Julia integer indices to the inclusive-exclusive semantics Onda/TimeSpans use, and allows for roundtripping and sensible durations:
+This choice of conversion matches the inclusive-inclusive indexing of Julia integer indices to the inclusive-exclusive semantics Onda/TimeSpans use, and allows for roundtripping and sensible durations. Indices `2:3` at a sample rate of 1Hz, and the `TimeSpan` they're associated to:
+
+```@raw html
+<div class="aligned-spans-widget" data-scenario="index-to-time" data-results="given"></div>
+```
+
+This is verified in code:
 
 ```jldoctest
 julia> using AlignedSpans, TimeSpans, Dates
@@ -86,6 +92,12 @@ true
 
     Even though `RoundInward` and `RoundSpanDown` both round the right endpoint down, `TimeSpan(aligned)` is `TimeSpan(0, Second(60))`, not `TimeSpan(0, Second(30) + Nanosecond(1))`. That's because indices 1 and 2 correspond to the time from the first sample until just before the sample that would come after index 2, which occurs at `Second(60)`.
 
+    The shaded region below is the input span; the dots are individual samples at 1/30Hz; the colored bracket is the resulting `AlignedSpan`, converted back to a `TimeSpan`:
+
+    ```@raw html
+    <div class="aligned-spans-widget" data-scenario="rounding-grows-span" data-results="RoundInward"></div>
+    ```
+
 ## Motivation
 
 Let's say I want to plot some samples over time, and I have a nice function `plot(::TimeSpan, ::Samples)` to use.
@@ -112,6 +124,12 @@ Let's take a look at the samples we are plotting:
 samples[:, span] # TimeSpans v0.2; v0.3 will have one more sample
 ```
 These are three samples that correspond to times 1s, 2s, and 3s. However, what we gave to the `x`-axis of our plotting function is `TimeSpan(Millisecond(1500), Millisecond(3500))`, which starts at 1.5s and goes to 3.5s. In other words, our plot will have an incorrect 0.5s offset!
+
+The shaded region below is the (wrong) span we plotted against; the bracket is the (correct) span the samples actually cover:
+
+```@raw html
+<div class="aligned-spans-widget" data-scenario="motivation-offset" data-results="RoundSpanDown"></div>
+```
 
 Note that `plot` is just an example; any function where one is separately passing both a "timespan of interest" and "feature values from that timespan" will have similar issues if one isn't careful about what exactly `samples[:, span]` is doing.
 

--- a/docs/widget_data.jl
+++ b/docs/widget_data.jl
@@ -1,0 +1,218 @@
+# Generates docs/src/assets/generated/aligned-spans-widget-data.js, consumed
+# by docs/src/assets/aligned-spans-widget.js to render the visualization
+# widgets embedded in the docs.
+#
+# Every number here comes from actually calling AlignedSpans/TimeSpans code
+# (never hand-computed), so the widget can never show something that
+# disagrees with the real package behavior -- including the precision
+# nuances (Rational sample rates, etc.) that are the whole point of some of
+# these scenarios. The JS side does no rounding/time-conversion math at all;
+# it only positions and highlights boxes based on the numbers generated here.
+
+using AlignedSpans, TimeSpans, Dates, JSON
+
+# A single AlignedSpan's index range and its TimeSpan, as plain JSON-able data.
+function entry(aligned::AlignedSpan)
+    ts = TimeSpan(aligned)
+    return Dict(
+        "first_index" => aligned.first_index,
+        "last_index" => aligned.last_index,
+        "timespan_start_ns" => Dates.value(TimeSpans.start(ts)),
+        "timespan_stop_ns" => Dates.value(TimeSpans.stop(ts)),
+    )
+end
+
+# Precomputed {index, time_ns} pairs covering `indices`, with `pad` samples
+# of padding on the low end and `pad + 1` on the high end (the extra sample
+# on the high end lets the renderer draw the "next sample" boundary needed
+# for span-style, e.g. RoundFullyContainedSampleSpans, rendering).
+function window_for(sample_rate, indices; pad=2)
+    lo = minimum(indices) - pad
+    hi = maximum(indices) + pad + 1
+    return [
+        Dict("index" => i, "time_ns" => Dates.value(AlignedSpans.time_from_index(sample_rate, i)))
+        for i in lo:hi
+    ]
+end
+
+function span_dict(ts::TimeSpan)
+    return Dict(
+        "start_ns" => Dates.value(TimeSpans.start(ts)),
+        "stop_ns" => Dates.value(TimeSpans.stop(ts)),
+    )
+end
+
+all_indices(aligneds) = vcat([[a.first_index, a.last_index] for a in aligneds]...)
+
+scenarios = Dict{String, Any}()
+
+# "Sample index -> Time", index.md / decisions.md: plain index range, no rounding.
+let
+    rate = 1
+    aligned = AlignedSpan(rate, 2:3)
+    scenarios["index-to-time"] = Dict(
+        "sample_rate" => string(rate),
+        "input_span" => nothing,
+        "window" => window_for(rate, [2, 3]),
+        "results" => Dict("given" => [entry(aligned)]),
+    )
+end
+
+# The "span looks larger after rounding" warning, index.md; also the
+# hypnograms section, examples.md.
+let
+    rate = 1 // 30
+    input = TimeSpan(0, Second(30) + Nanosecond(1))
+    modes = Dict(
+        "RoundInward" => AlignedSpan(rate, input, RoundInward),
+        "RoundSpanDown" => AlignedSpan(rate, input, RoundSpanDown),
+        "RoundFullyContainedSampleSpans" => AlignedSpan(rate, input, RoundFullyContainedSampleSpans),
+    )
+    scenarios["rounding-grows-span"] = Dict(
+        "sample_rate" => string(rate),
+        "input_span" => span_dict(input),
+        "window" => window_for(rate, all_indices(values(modes))),
+        "results" => Dict(k => [entry(v)] for (k, v) in modes),
+    )
+end
+
+# EEG / instant-like samples and Onda-indexing sections, examples.md;
+# "Rounding modes: why four" section, decisions.md uses a shorter span --
+# see "decisions-modes-example" below.
+let
+    rate = 1
+    input = TimeSpan(Millisecond(1500), Millisecond(3500))
+    modes = Dict(
+        "RoundSpanDown" => AlignedSpan(rate, input, RoundSpanDown),
+        "RoundInward" => AlignedSpan(rate, input, RoundInward),
+    )
+    scenarios["eeg-onda-indexing"] = Dict(
+        "sample_rate" => string(rate),
+        "input_span" => span_dict(input),
+        "window" => window_for(rate, all_indices(values(modes))),
+        "results" => Dict(k => [entry(v)] for (k, v) in modes),
+    )
+end
+
+# Motivation section, index.md: the plotting-offset example.
+let
+    rate = 1
+    input = TimeSpan(Millisecond(1500), Millisecond(4000))
+    aligned = AlignedSpan(rate, input, RoundSpanDown)
+    scenarios["motivation-offset"] = Dict(
+        "sample_rate" => string(rate),
+        "input_span" => span_dict(input),
+        "window" => window_for(rate, [aligned.first_index, aligned.last_index]),
+        "results" => Dict("RoundSpanDown" => [entry(aligned)]),
+    )
+end
+
+# "Rounding modes: why four, and how they're named", decisions.md.
+let
+    rate = 1
+    input = TimeSpan(Millisecond(1500), Millisecond(2500))
+    modes = Dict(
+        "RoundSpanDown" => AlignedSpan(rate, input, RoundSpanDown),
+        "RoundInward" => AlignedSpan(rate, input, RoundInward),
+    )
+    scenarios["decisions-modes-example"] = Dict(
+        "sample_rate" => string(rate),
+        "input_span" => span_dict(input),
+        "window" => window_for(rate, all_indices(values(modes))),
+        "results" => Dict(k => [entry(v)] for (k, v) in modes),
+    )
+end
+
+# "Getting a consistent number of samples across spans", examples.md: two
+# same-duration spans, one scenario each so both can be shown side by side.
+for (name, input) in (
+        "constant-samples-1" => TimeSpan(Millisecond(0), Millisecond(700)),
+        "constant-samples-2" => TimeSpan(Millisecond(100), Millisecond(800)),
+    )
+    rate = 3
+    modes = Dict(
+        "RoundInward" => AlignedSpan(rate, input, RoundInward),
+        "ConstantSamplesRoundingMode" => AlignedSpan(rate, input, ConstantSamplesRoundingMode(RoundDown)),
+    )
+    scenarios[name] = Dict(
+        "sample_rate" => string(rate),
+        "input_span" => span_dict(input),
+        "window" => window_for(rate, all_indices(values(modes))),
+        "results" => Dict(k => [entry(v)] for (k, v) in modes),
+    )
+end
+
+# "Splitting a span into fixed-size or sliding windows", examples.md;
+# `keep_last` deferred-decision entry, decisions.md.
+let
+    rate = 1
+    base = AlignedSpan(rate, 1:10)
+    windows = collect(consecutive_subspans(base, 3))
+    windows_keep_last_false = collect(consecutive_subspans(base, 3; keep_last=false))
+    windows_overlapping = collect(consecutive_overlapping_subspans(base, 3, 2))
+    all_spans = vcat(windows, windows_keep_last_false, windows_overlapping)
+    scenarios["windowing"] = Dict(
+        "sample_rate" => string(rate),
+        "input_span" => nothing,
+        "window" => window_for(rate, all_indices(all_spans)),
+        "results" => Dict(
+            "windows" => [entry(w) for w in windows],
+            "windows-keep-last-false" => [entry(w) for w in windows_keep_last_false],
+            "windows-overlapping" => [entry(w) for w in windows_overlapping],
+        ),
+    )
+end
+
+# "Spans that start before or run past your recording", examples.md: direct
+# out-of-range index construction (no rounding involved).
+let
+    rate = 1
+    aligned = AlignedSpan(rate, -5:10)
+    scenarios["out-of-range-raw"] = Dict(
+        "sample_rate" => string(rate),
+        "input_span" => nothing,
+        "window" => window_for(rate, [aligned.first_index, aligned.last_index]),
+        "results" => Dict("given" => [entry(aligned)]),
+    )
+end
+
+# Negative-`sample_time` deferred-decision entry, decisions.md; issue #15's
+# original MWE (constructing from a TimeSpan with a negative start time).
+let
+    rate = 1238
+    input = TimeSpan(Nanosecond(-32), Nanosecond(2))
+    aligned = AlignedSpan(rate, input, RoundSpanDown)
+    scenarios["out-of-range-timespan"] = Dict(
+        "sample_rate" => string(rate),
+        "input_span" => span_dict(input),
+        "window" => window_for(rate, [aligned.first_index, aligned.last_index]),
+        "results" => Dict("RoundSpanDown" => [entry(aligned)]),
+    )
+end
+
+# "Shifting a span in time", examples.md; `TimeSpans.translate`
+# deferred-decision entry, decisions.md.
+let
+    rate = 3
+    original = AlignedSpan(rate, 1:10)
+    n = n_samples(rate, Second(1))
+    shifted = AlignedSpan(rate, (original.first_index + n):(original.last_index + n))
+    scenarios["shifting"] = Dict(
+        "sample_rate" => string(rate),
+        "input_span" => nothing,
+        "window" => window_for(rate, all_indices([original, shifted])),
+        "results" => Dict(
+            "original" => [entry(original)],
+            "shifted" => [entry(shifted)],
+        ),
+    )
+end
+
+generated_dir = joinpath(@__DIR__, "src", "assets", "generated")
+mkpath(generated_dir)
+open(joinpath(generated_dir, "aligned-spans-widget-data.js"), "w") do io
+    write(io, "// Generated by docs/widget_data.jl -- do not edit, and do not commit.\n")
+    write(io, "window.ALIGNED_SPANS_SCENARIOS = ")
+    JSON.print(io, scenarios)
+    write(io, ";\n")
+end


### PR DESCRIPTION
See [HERE](https://beacon-biosignals.github.io/AlignedSpans.jl/previews/PR61/) for the docs preview

Built on #60

I used Claude sonnet 5 medium to create a tiny bit of css/js and a julia script. We have a list of scenarios in the julia script for which we populate time<>index conversions using AlignedSpans an generate some json at docs build time which is not checked in. Then the docs can pull those examples to show illustrations. The idea is we don't reimplement the logic in js (like Claude wanted to do originally) but still get some nice simple illustrations.

This tries to make the ideas more understandable.

## Examples
[<img width="871" height="490" alt="Screenshot 2026-08-04 at 14 46 50" src="https://github.com/user-attachments/assets/f6f28c1b-9d71-4ecf-8035-b4348d02f1d4" />
](https://beacon-biosignals.github.io/AlignedSpans.jl/previews/PR61/examples/#EEG-and-other-instant-like-samples)[<img width="891" height="965" alt="Screenshot 2026-08-04 at 14 47 08" src="https://github.com/user-attachments/assets/3fb4ee46-8873-4380-9130-7804e7a4ad6c" />
](https://beacon-biosignals.github.io/AlignedSpans.jl/previews/PR61/examples/#Getting-a-consistent-number-of-samples-across-spans)
