### PR TITLE
[docs-deploy] avoid race conditions by adding concurrency group

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,10 @@ on:
     tags: [v*]
   pull_request:
 
+concurrency:
+  group: docs-deploy
+  cancel-in-progress: false
+
 jobs:
   Documenter:
     name: Documentation


### PR DESCRIPTION
The docs failed to deploy on v0.2.10; claude thinks there was a race and a deployment got cancelled bc of tagbot pushing multiple tags:

> 11:23:42 — TagBot ran and failed with "TagBot trigger issue."
> 11:27:52 — A push to tag v0.1.0 (pointing at an old commit, 6e701ac7...) triggered the Documenter workflow ([docs.yml](vscode-webview://1vej61hhonkkkg27lt99lre0ru7r720evks6eodkpgbu7a6pf0er/Users/eph/AlignedSpans.jl/.github/workflows/docs.yml)) — run [31097360697](https://github.com/beacon-biosignals/AlignedSpans.jl/actions/runs/31097360697).
> 11:28:25 — Just 33 seconds later, a push to tag v0.2.10 (pointing at 7d8fe353...) triggered a second, independent Documenter run — [31097396696](https://github.com/beacon-biosignals/AlignedSpans.jl/actions/runs/31097396696).
> Both of these are real, separate push events (verified via head_branch/head_sha/event on the raw run data — not a webhook duplicate), each running julia-docdeploy, which force-pushes to gh-pages. Since these ran ~30s apart and a docs build+deploy typically takes 1-3 minutes, they overlapped and both raced to force-push gh-pages around 11:29-11:32 — matching the two gh-pages commits (e3e77094... then ef86314f...) we found landing seconds apart.

It suggested this fix, which makes sense to me.